### PR TITLE
Fixup GH workflow for releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          
+      - name: Fetch tags
+        if: ${{ github.event_name == 'release' }}
+        run: |
+          git fetch --tags --force
 
       - name: Install packages
         run: |


### PR DESCRIPTION
Running the workflow from a tag (triggered by release) leads
to overwriting the tag metadata in the runners working copy.
Hence, the release will not pick up data and changelog, correctly.
By force-fetching all tags all the tag metadata is restored.

Relates to actions/checkout#290