### PR TITLE
Doxygen: Fix generation of dev drop versions.

### DIFF
--- a/Doxygen/gen_doc.sh
+++ b/Doxygen/gen_doc.sh
@@ -60,7 +60,8 @@ fi
 sed -e "s/{datetime}/${datetime}/" "${DIRNAME}/templates/footer.js.in" \
   | sed -e "s/{year}/${year}/" \
   | sed -e "s/{projectName}/${projectName}/" \
-  | sed -e "s/{projectNumber}/${VERSION_FULL}/" \
+  | sed -e "s/{projectNumber}/${VERSION}/" \
+  | sed -e "s/{projectNumberFull}/${VERSION_FULL}/" \
   > "${DIRNAME}/../Documentation/html/footer.js"
 
 exit 0

--- a/Doxygen/templates/footer.js.in
+++ b/Doxygen/templates/footer.js.in
@@ -3,5 +3,5 @@ function writeHeader() {
 };
 
 function writeFooter()  {
-    document.write('Generated on {datetime} for {projectName} {projectNumber}. Copyright &copy; {year} Arm Limited (or its affiliates). All rights reserved.');
+    document.write('Generated on {datetime} for {projectName} {projectNumberFull}. Copyright &copy; {year} Arm Limited (or its affiliates). All rights reserved.');
 };


### PR DESCRIPTION
Version number in the header is displayed without
the Git commit id. The commit id is only used in
the footer.