### PR TITLE
Fix uninitialised variable references reported by GCC 12

### DIFF
--- a/Source/MatrixFunctions/arm_mat_add_f16.c
+++ b/Source/MatrixFunctions/arm_mat_add_f16.c
@@ -62,7 +62,7 @@ arm_status arm_mat_add_f16(
     arm_status status;  
     uint32_t  numSamples;       /* total number of elements in the matrix  */
     float16_t *pDataA, *pDataB, *pDataDst;
-    f16x8_t vecA, vecB, vecDst;
+    f16x8_t vecA, vecB, vecDst = { 0 };
     float16_t const *pSrcAVec;
     float16_t const *pSrcBVec;
     uint32_t  blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_add_f32.c
+++ b/Source/MatrixFunctions/arm_mat_add_f32.c
@@ -88,7 +88,7 @@ arm_status arm_mat_add_f32(
     arm_status status;  
     uint32_t  numSamples;       /* total number of elements in the matrix  */
     float32_t *pDataA, *pDataB, *pDataDst;
-    f32x4_t vecA, vecB, vecDst;
+    f32x4_t vecA, vecB, vecDst = { 0 };
     float32_t const *pSrcAVec;
     float32_t const *pSrcBVec;
     uint32_t  blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_add_q15.c
+++ b/Source/MatrixFunctions/arm_mat_add_q15.c
@@ -59,7 +59,7 @@ arm_status arm_mat_add_q15(
 {
     uint32_t        numSamples;       /* total number of elements in the matrix  */
     q15_t          *pDataA, *pDataB, *pDataDst;
-    q15x8_t       vecA, vecB, vecDst;
+    q15x8_t       vecA, vecB, vecDst = { 0 };
     q15_t const   *pSrcAVec;
     q15_t const   *pSrcBVec;
     uint32_t        blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_add_q31.c
+++ b/Source/MatrixFunctions/arm_mat_add_q31.c
@@ -59,7 +59,7 @@ arm_status arm_mat_add_q31(
     arm_status status;                             /* status of matrix addition */
     uint32_t        numSamples;       /* total number of elements in the matrix  */
     q31_t          *pDataA, *pDataB, *pDataDst;
-    q31x4_t       vecA, vecB, vecDst;
+    q31x4_t       vecA, vecB, vecDst = { 0 };
     q31_t const   *pSrcAVec;
     q31_t const   *pSrcBVec;
     uint32_t        blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_sub_f16.c
+++ b/Source/MatrixFunctions/arm_mat_sub_f16.c
@@ -60,7 +60,7 @@ arm_status arm_mat_sub_f16(
     arm_status status;                             /* status of matrix subtraction */
     uint32_t  numSamples;       /* total number of elements in the matrix  */
     float16_t *pDataA, *pDataB, *pDataDst;
-    f16x8_t vecA, vecB, vecDst;
+    f16x8_t vecA, vecB, vecDst = { 0 };
     float16_t const *pSrcAVec;
     float16_t const *pSrcBVec;
     uint32_t  blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_sub_f32.c
+++ b/Source/MatrixFunctions/arm_mat_sub_f32.c
@@ -85,7 +85,7 @@ arm_status arm_mat_sub_f32(
     arm_status status;                             /* status of matrix subtraction */
     uint32_t  numSamples;       /* total number of elements in the matrix  */
     float32_t *pDataA, *pDataB, *pDataDst;
-    f32x4_t vecA, vecB, vecDst;
+    f32x4_t vecA, vecB, vecDst = { 0 };
     float32_t const *pSrcAVec;
     float32_t const *pSrcBVec;
     uint32_t  blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_sub_q15.c
+++ b/Source/MatrixFunctions/arm_mat_sub_q15.c
@@ -59,7 +59,7 @@ arm_status arm_mat_sub_q15(
 {
     uint32_t        numSamples;       /* total number of elements in the matrix  */
     q15_t          *pDataA, *pDataB, *pDataDst;
-    q15x8_t       vecA, vecB, vecDst;
+    q15x8_t       vecA, vecB, vecDst = { 0 };
     q15_t const   *pSrcAVec;
     q15_t const   *pSrcBVec;
     uint32_t        blkCnt;           /* loop counters */

--- a/Source/MatrixFunctions/arm_mat_sub_q31.c
+++ b/Source/MatrixFunctions/arm_mat_sub_q31.c
@@ -58,7 +58,7 @@ arm_status arm_mat_sub_q31(
 {
     uint32_t        numSamples;       /* total number of elements in the matrix  */
     q31_t          *pDataA, *pDataB, *pDataDst;
-    q31x4_t       vecA, vecB, vecDst;
+    q31x4_t       vecA, vecB, vecDst = { 0 };
     q31_t const   *pSrcAVec;
     q31_t const   *pSrcBVec;
     uint32_t        blkCnt;           /* loop counters */

--- a/Source/SupportFunctions/arm_float_to_q15.c
+++ b/Source/SupportFunctions/arm_float_to_q15.c
@@ -68,7 +68,7 @@ void arm_float_to_q15(
     uint32_t         blkCnt;
     float32_t       maxQ = (float32_t) Q15_MAX;
     f32x4x2_t       tmp;
-    q15x8_t         vecDst;
+    q15x8_t         vecDst = { 0 };
 #ifdef ARM_MATH_ROUNDING
     float32_t in;
 #endif

--- a/Source/SupportFunctions/arm_float_to_q7.c
+++ b/Source/SupportFunctions/arm_float_to_q7.c
@@ -67,8 +67,8 @@ void arm_float_to_q7(
     uint32_t         blkCnt;     /* loop counters */
     float32_t       maxQ = powf(2.0, 7);
     f32x4x4_t       tmp;
-    q15x8_t         evVec, oddVec;
-    q7x16_t         vecDst;
+    q15x8_t         evVec = { 0 }, oddVec = { 0 };
+    q7x16_t         vecDst = { 0 };
     float32_t const *pSrcVec;
 #ifdef ARM_MATH_ROUNDING
     float32_t in;

--- a/Source/SupportFunctions/arm_q15_to_q7.c
+++ b/Source/SupportFunctions/arm_q15_to_q7.c
@@ -60,7 +60,7 @@ void arm_q15_to_q7(
     uint32_t  blkCnt;           /* loop counters */
     q15x8x2_t tmp;
     q15_t const *pSrcVec;
-    q7x16_t vecDst;
+    q7x16_t vecDst = { 0 };
 
 
     pSrcVec = (q15_t const *) pSrc;

--- a/Source/SupportFunctions/arm_q31_to_q15.c
+++ b/Source/SupportFunctions/arm_q31_to_q15.c
@@ -58,7 +58,7 @@ void arm_q31_to_q15(
 {
     uint32_t  blkCnt;           /* loop counters */
     q31x4x2_t tmp;
-    q15x8_t vecDst;
+    q15x8_t vecDst = { 0 };
     q31_t const *pSrcVec;
 
 

--- a/Source/SupportFunctions/arm_q31_to_q7.c
+++ b/Source/SupportFunctions/arm_q31_to_q7.c
@@ -58,8 +58,8 @@ void arm_q31_to_q7(
 {
     uint32_t  blkCnt;           /* loop counters */
     q31x4x4_t tmp;
-    q15x8_t evVec, oddVec;
-    q7x16_t  vecDst;
+    q15x8_t evVec = { 0 }, oddVec = { 0 };
+    q7x16_t  vecDst = { 0 };
     q31_t const *pSrcVec;
 
     pSrcVec = (q31_t const *) pSrc;


### PR DESCRIPTION
This commit fixes the uninitialised variable reference warnings
reported by GCC 12.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #41 