### PR TITLE
Add braces around MAX macro

### DIFF
--- a/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_module.h
+++ b/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_module.h
@@ -35,7 +35,7 @@
 #endif
 
 #include <Python.h>
-#define MAX(A,B) (A) < (B) ? (B) : (A)
+#define MAX(A,B) ((A) < (B) ? (B) : (A))
 
 #define CAT1(A,B) A##B
 #define CAT(A,B) CAT1(A,B)


### PR DESCRIPTION
The current implementation leads to wrong calculation of output lengths.

Fixes #76 