### PR TITLE
use 32-bit bitreversal loop index

### DIFF
--- a/Source/TransformFunctions/arm_bitreversal2.c
+++ b/Source/TransformFunctions/arm_bitreversal2.c
@@ -43,7 +43,8 @@ void arm_bitreversal_64(
   const uint16_t bitRevLen,
   const uint16_t *pBitRevTab)
 {
-  uint64_t a, b, i, tmp;
+  uint64_t a, b, tmp;
+  uint32_t i;
 
   for (i = 0; i < bitRevLen; )
   {
@@ -112,7 +113,8 @@ void arm_bitreversal_16(
   const uint16_t bitRevLen,
   const uint16_t *pBitRevTab)
 {
-  uint16_t a, b, i, tmp;
+  uint16_t a, b, tmp;
+  uint32_t i;
 
   for (i = 0; i < bitRevLen; )
   {


### PR DESCRIPTION
Always use 32-bit bitreversal loop indexes to save a few carry instructions for 64bit reversals, and save a few conversion instructions for 16bit reversals.
