### PR TITLE
Mark internal FFT functions as static

### DIFF
--- a/Source/TransformFunctions/arm_rfft_fast_f16.c
+++ b/Source/TransformFunctions/arm_rfft_fast_f16.c
@@ -34,7 +34,7 @@
 
 #if defined(ARM_MATH_MVE_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE)
 
-void stage_rfft_f16(
+static void stage_rfft_f16(
   const arm_rfft_fast_instance_f16 * S,
         float16_t * p,
         float16_t * pOut)
@@ -194,7 +194,7 @@ void stage_rfft_f16(
 }
 
 /* Prepares data for inverse cfft */
-void merge_rfft_f16(
+static void merge_rfft_f16(
   const arm_rfft_fast_instance_f16 * S,
         float16_t * p,
         float16_t * pOut)
@@ -313,7 +313,7 @@ void merge_rfft_f16(
 
 }
 #else
-void stage_rfft_f16(
+static void stage_rfft_f16(
   const arm_rfft_fast_instance_f16 * S,
         float16_t * p,
         float16_t * pOut)
@@ -402,7 +402,7 @@ void stage_rfft_f16(
 }
 
 /* Prepares data for inverse cfft */
-void merge_rfft_f16(
+static void merge_rfft_f16(
   const arm_rfft_fast_instance_f16 * S,
         float16_t * p,
         float16_t * pOut)

--- a/Source/TransformFunctions/arm_rfft_fast_f32.c
+++ b/Source/TransformFunctions/arm_rfft_fast_f32.c
@@ -29,7 +29,7 @@
 #include "dsp/transform_functions.h"
 
 #if defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE)
-void stage_rfft_f32(
+static void stage_rfft_f32(
   const arm_rfft_fast_instance_f32 * S,
         float32_t * p,
         float32_t * pOut)
@@ -188,7 +188,7 @@ void stage_rfft_f32(
 }
 
 /* Prepares data for inverse cfft */
-void merge_rfft_f32(
+static void merge_rfft_f32(
   const arm_rfft_fast_instance_f32 * S,
         float32_t * p,
         float32_t * pOut)
@@ -307,7 +307,7 @@ void merge_rfft_f32(
 
 }
 #else
-void stage_rfft_f32(
+static void stage_rfft_f32(
   const arm_rfft_fast_instance_f32 * S,
         float32_t * p,
         float32_t * pOut)
@@ -396,7 +396,7 @@ void stage_rfft_f32(
 }
 
 /* Prepares data for inverse cfft */
-void merge_rfft_f32(
+static void merge_rfft_f32(
   const arm_rfft_fast_instance_f32 * S,
         float32_t * p,
         float32_t * pOut)

--- a/Source/TransformFunctions/arm_rfft_fast_f64.c
+++ b/Source/TransformFunctions/arm_rfft_fast_f64.c
@@ -28,7 +28,7 @@
 
 #include "dsp/transform_functions.h"
 
-void stage_rfft_f64(
+static void stage_rfft_f64(
   const arm_rfft_fast_instance_f64 * S,
         float64_t * p,
         float64_t * pOut)
@@ -115,7 +115,7 @@ void stage_rfft_f64(
 }
 
 /* Prepares data for inverse cfft */
-void merge_rfft_f64(
+static void merge_rfft_f64(
   const arm_rfft_fast_instance_f64 * S,
         float64_t * p,
         float64_t * pOut)


### PR DESCRIPTION
This results in a slightly smaller overall FFT function when the compiler inlines the stage/merge functions, when it might not otherwise.

This also resolves the GCC warnings:
warning: no previous declaration for 'merge_rfft_f16' [-Wmissing-declarations]
warning: no previous declaration for 'merge_rfft_f32' [-Wmissing-declarations]
warning: no previous declaration for 'merge_rfft_f64' [-Wmissing-declarations]
warning: no previous declaration for 'stage_rfft_f16' [-Wmissing-declarations]
warning: no previous declaration for 'stage_rfft_f32' [-Wmissing-declarations]
warning: no previous declaration for 'stage_rfft_f64' [-Wmissing-declarations]