### PR TITLE
include statistics header

### DIFF
--- a/Source/StatisticsFunctions/arm_accumulate_f64.c
+++ b/Source/StatisticsFunctions/arm_accumulate_f64.c
@@ -26,7 +26,7 @@
  * limitations under the License.
  */
 
-#include "dsp/basic_math_functions.h"
+#include "dsp/statistics_functions.h"
 
 /**
  @ingroup groupStats


### PR DESCRIPTION
Include statistics header for arm_accumulate_f64, same as how _f32 version works to address the following GCC warning when enabled:

Source/StatisticsFunctions/arm_accumulate_f64.c:97:6: warning: no previous declaration for 'arm_accumulate_f64' [-Wmissing-declarations]
   97 | void arm_accumulate_f64(
      |      ^~~~~~~~~~~~~~~~~~