### PR TITLE
Fix pragma clang warning with gcc

### DIFF
--- a/Source/StatisticsFunctions/arm_mse_f64.c
+++ b/Source/StatisticsFunctions/arm_mse_f64.c
@@ -111,7 +111,8 @@ void arm_mse_f64(
 #endif
 #endif
 
-#if defined(ARM_MATH_NEON) && defined(__aarch64__)
+#if defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050) && \
+    defined(ARM_MATH_NEON) && defined(__aarch64__)
     #pragma clang loop vectorize(enable) unroll(disable)
 #endif
     while (blkCnt > 0U)


### PR DESCRIPTION
When compiling with gcc a warning will appear for #pragma clang as it will be ignored. Add a conditional compile so only armclang will see the pragma clang.