### PR TITLE
prevent redefinition of ROUND_UP

### DIFF
--- a/Include/dsp/utils.h
+++ b/Include/dsp/utils.h
@@ -50,7 +50,9 @@ extern "C"
 
 #define SQ(x) ((x) * (x))
 
-#define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
+#ifndef ROUND_UP
+  #define ROUND_UP(N, S) ((((N) + (S) - 1) / (S)) * (S))
+#endif
 
 
   /**


### PR DESCRIPTION
It is possible that large projects may already have a definition of `ROUND_UP` such as Zephyr. This prevents a redefinition of `ROUND_UP`