### PR TITLE
fix uninitialized variable references

### DIFF
--- a/Include/arm_helium_utils.h
+++ b/Include/arm_helium_utils.h
@@ -112,7 +112,7 @@ __STATIC_FORCEINLINE float16x8_t __mve_cmplx_sum_intra_vec_f16(
     float16x8_t   vecIn)
 {
     float16x8_t   vecTmp, vecOut;
-    uint32_t    tmp;
+    uint32_t    tmp = 0;
 
     vecTmp = (float16x8_t) vrev64q_s32((int32x4_t) vecIn);
     // TO TRACK : using canonical addition leads to unefficient code generation for f16

--- a/Source/BasicMathFunctions/arm_scale_q15.c
+++ b/Source/BasicMathFunctions/arm_scale_q15.c
@@ -64,7 +64,7 @@ void arm_scale_q15(
 {
     uint32_t  blkCnt;           /* loop counters */
     q15x8_t vecSrc;
-    q15x8_t vecDst;
+    q15x8_t vecDst = { 0 };
     q31x4_t low, high;
 
     /* Compute 8 outputs at a time */

--- a/Source/BasicMathFunctions/arm_scale_q7.c
+++ b/Source/BasicMathFunctions/arm_scale_q7.c
@@ -64,7 +64,7 @@ void arm_scale_q7(
 {
     uint32_t  blkCnt;           /* loop counters */
     q7x16_t vecSrc;
-    q7x16_t vecDst;
+    q7x16_t vecDst = { 0 };
     q15x8_t low, high;
 
 

--- a/Source/InterpolationFunctions/arm_spline_interp_f32.c
+++ b/Source/InterpolationFunctions/arm_spline_interp_f32.c
@@ -165,17 +165,17 @@ void arm_spline_f32(
     float32_t x_sc;
 
 #ifdef ARM_MATH_NEON
-    float32x4_t xiv;
-    float32x4_t aiv;
-    float32x4_t biv;
-    float32x4_t civ;
-    float32x4_t div;
+    float32x4_t xiv = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t aiv = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t biv = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t civ = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t div = {0.0f, 0.0f, 0.0f, 0.0f};
 
-    float32x4_t xqv;
+    float32x4_t xqv = {0.0f, 0.0f, 0.0f, 0.0f};
 
-    float32x4_t temp;
-    float32x4_t diff;
-    float32x4_t yv;
+    float32x4_t temp = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t diff = {0.0f, 0.0f, 0.0f, 0.0f};
+    float32x4_t yv = {0.0f, 0.0f, 0.0f, 0.0f};
 #endif
 
     /* Create output for x(i)<x<x(i+1) */


### PR DESCRIPTION
This commit adds initialization for the variables that can be used potentially uninitialized so that GCC does not generate warnings while building.