### PR TITLE
Version 1.9.8: unfixed numpy from 1.22

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,5 @@ include PythonWrapper_README.md
 recursive-include Include *.h 
 recursive-include PrivateInclude *.h 
 recursive-include PythonWrapper/cmsisdsp_pkg/src *.h 
-include cmsisdsp/cg/scheduler/templates/*
 include Source/DistanceFunctions/arm_boolean_distance_template.h
 

--- a/PythonWrapper/build/create.bat
+++ b/PythonWrapper/build/create.bat
@@ -1,7 +1,7 @@
 cmake -DHOST=YES ^
   -DLOOPUNROLL=ON ^
   -DWRAPPER=YES ^
-  -DCMSISDSP="path to CMSIS-DSP folder" ^
+  -DCMSISDSP=".." ^
   -DCMAKE_C_FLAGS_RELEASE="-std=c11 -Ofast -ffast-math -DNDEBUG -Wall -Wextra" ^
   -DCMAKE_CXX_FLAGS_RELEASE="-fno-rtti -std=c++11 -Ofast -ffast-math -DNDEBUG -Wall -Wextra -Wno-unused-parameter" ^
   -G "Unix Makefiles" ..

--- a/PythonWrapper/build_linux/create.sh
+++ b/PythonWrapper/build_linux/create.sh
@@ -2,7 +2,7 @@ cmake -DHOST=YES \
   -DLOOPUNROLL=ON \
   -DWRAPPER=YES \
   -DCMAKE_POSITION_INDEPENDENT_CODE=YES \
-  -DCMSISDSP="path to CMSIS-DSP folder" \
+  -DCMSISDSP=".." \
   -DCMAKE_C_FLAGS_RELEASE="-std=c11 -Ofast -ffast-math -DNDEBUG -Wall -Wextra" \
   -DCMAKE_CXX_FLAGS_RELEASE="-fno-rtti -std=c++11 -Ofast -ffast-math -DNDEBUG -Wall -Wextra -Wno-unused-parameter" \
   -G "Unix Makefiles" ..

--- a/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_distance.c
+++ b/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_distance.c
@@ -227,7 +227,7 @@ cmsis_arm_dtw_init_window_q7(PyObject *obj,
   arm_matrix_instance_q7 pSrc_converted; // input
    
 
-  if (PyArg_ParseTuple(args,"iiO",&winType,&winSize,&pSrc));
+  if (PyArg_ParseTuple(args,"iiO",&winType,&winSize,&pSrc))
   {
 
     q7MatrixFromNumpy(&pSrc_converted,pSrc);
@@ -267,7 +267,7 @@ cmsis_arm_dtw_distance_f32(PyObject *obj,
   arm_matrix_instance_f32 dtw_converted;
 
 
-  if (PyArg_ParseTuple(args,"OO",&pDist,&pWin));
+  if (PyArg_ParseTuple(args,"OO",&pDist,&pWin))
   {
 
     f32MatrixFromNumpy(&pDist_converted,pDist);
@@ -348,7 +348,7 @@ cmsis_arm_dtw_path_f32(PyObject *obj,
      Py_DECREF(pDstOBJ);
      return(pythonResult);
   }
-
+  Py_RETURN_NONE;
 }
 
 static PyMethodDef CMSISDSPMethods[] = {

--- a/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_module.h
+++ b/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_module.h
@@ -32,9 +32,9 @@
 #include <numpy/numpyconfig.h>
 
 // API version used on google colab
-// List on https://github.com/numpy/numpy/blob/main/numpy/core/include/numpy/numpyconfig.h
+// List in https://github.com/numpy/numpy numpyconfig.h
 #if (NPY_API_VERSION != 0x0000000F )
-#error("Error building with wrong NumPy API version")
+//#error("Error building with wrong NumPy API version")
 #endif
 
 #ifdef WIN

--- a/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_window.c
+++ b/PythonWrapper/cmsisdsp_pkg/src/cmsisdsp_window.c
@@ -72,7 +72,7 @@ cmsis_arm_welch_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -125,7 +125,7 @@ cmsis_arm_bartlett_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -178,7 +178,7 @@ cmsis_arm_hamming_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -231,7 +231,7 @@ cmsis_arm_hanning_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -284,7 +284,7 @@ cmsis_arm_nuttall3_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -337,7 +337,7 @@ cmsis_arm_nuttall4_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -390,7 +390,7 @@ cmsis_arm_nuttall3a_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -443,7 +443,7 @@ cmsis_arm_nuttall3b_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -496,7 +496,7 @@ cmsis_arm_nuttall4a_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -549,7 +549,7 @@ cmsis_arm_blackman_harris_92db_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -602,7 +602,7 @@ cmsis_arm_nuttall4b_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -655,7 +655,7 @@ cmsis_arm_nuttall4c_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -708,7 +708,7 @@ cmsis_arm_hft90d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -761,7 +761,7 @@ cmsis_arm_hft95_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -814,7 +814,7 @@ cmsis_arm_hft116d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -867,7 +867,7 @@ cmsis_arm_hft144d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -920,7 +920,7 @@ cmsis_arm_hft169d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -973,7 +973,7 @@ cmsis_arm_hft196d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -1026,7 +1026,7 @@ cmsis_arm_hft223d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))
@@ -1079,7 +1079,7 @@ cmsis_arm_hft248d_f64(PyObject *obj, PyObject *args)
 {
 
   
-  float32_t *pDst=NULL; // output
+  float64_t *pDst=NULL; // output
   int nb; // input
 
   if (PyArg_ParseTuple(args,"i",&nb))

--- a/PythonWrapper_README.md
+++ b/PythonWrapper_README.md
@@ -11,17 +11,13 @@ The signal processing chain can thus be tested and developed in a Python environ
 A tutorial is also available but with less details than this README:
 https://developer.arm.com/documentation/102463/latest/
 
-This wrapper is also containing the scripts for the new [CMSIS-DSP compute graph framework](https://github.com/ARM-software/CMSIS-DSP/tree/main/ComputeGraph) (CG).
-
-CG is also including some nodes to communicate with Modelica using the VHT Modelica blocks developed as part of our [VHT-SystemModeling](https://github.com/ARM-software/VHT-SystemModeling) demos.
-
 An history of the changes to this wrapper is available at the end of the README.
 
 # How to build and install
 
 ## Tested configurations
 
-The building of this package has been tested on Windows with the Python install from python.org and Microsoft Visual 2017. 
+The building of this package has been tested on Windows with the Python install from python.org and Microsoft Visual Studio 2022 and on Ubuntu 22.04.
 
 It has also been tested with `cygwin`. In that case, `python-devel` must be installed too. On Mac, it was tested with standard XCode installation.
 
@@ -42,8 +38,6 @@ It is advised to do it in a Python virtual environment. Then, in the virtual env
 You must have a recent `pip` (to automatically install the dependencies like `NumPy`) and you should have a compiler which can be found by Python when building the package.
 
 DSP examples are available in the [CMSIS-DSP PythonWrapper examples](https://github.com/ARM-software/CMSIS-DSP/tree/main/PythonWrapper/examples) folder.
-
-Synchronous Data Flow examples are available in the [ComputeGraph](https://github.com/ARM-software/CMSIS-DSP/tree/main/ComputeGraph) folder of [CMSIS-DSP](https://github.com/ARM-software/CMSIS-DSP) .
 
 You can also install and run it from [Google colab](https://colab.research.google.com/):
 
@@ -236,11 +230,14 @@ MEL filters are represented as 3 arrays to encode a sparse array.
 
 `datatype` is an API on top of `fixedpoint` to provide more reuse when converting between data formats.
 
-The wrapper is now containing the compute graph Python scripts and you should refer the the documentation in `DSP/ComputeGraph` folder to know how to use those tools.
-
 
 
 # Change history
+
+## Version 1.9.8:
+* Compute graph API has been removed
+* Dependency on numpy 1.22 has been lifted, tested through numpy 1.26
+* Inconsistencies in distance and window modules have been fixed.
 
 ## Version 1.9.7:
 

--- a/cmsisdsp/version.py
+++ b/cmsisdsp/version.py
@@ -1,2 +1,2 @@
 # Python wrapper version
-__version__ = "1.9.7"
+__version__ = "1.9.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "numpy>=1.22, < 1.23"
+    "numpy>=1.22"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -160,12 +160,7 @@ def build():
 
   setup (name = 'cmsisdsp',
          version = main_ns['__version__'],
-         packages=["cmsisdsp",
-                   "cmsisdsp.cg",
-                   "cmsisdsp.cg.nodes",
-                   "cmsisdsp.cg.nodes.host",
-                   "cmsisdsp.cg.scheduler",
-                   "cmsisdsp.cg.scheduler.templates"],
+         packages=["cmsisdsp"],
          description = 'CMSIS-DSP Python API',
          long_description=open("PythonWrapper_README.md").read(),
          long_description_content_type='text/markdown',
@@ -205,7 +200,8 @@ def build():
                 "Intended Audience :: Developers",
           ],
           keywords=['development','dsp','cmsis','cmsis-dsp','Arm','signal processing','maths','ml','cortex-m','cortex-a'],
-          install_requires=['numpy>=1.22, < 1.23 ',
+          install_requires=[
+          'numpy>=1.22',
           'networkx>=3.0',
           'jinja2>= 3.1.2, <4.0',
           'sympy>=1.7.1',


### PR DESCRIPTION
In PythonWrapper I removed the explicit dependency on numpy 1.22 and successfully tested the new version on Windows and Linux. 
At the time of writing Google Colab uses numpy 1.23 and numpy 1.26 is common, both have been tested with.
I fixed some bugs and inconsistencies in `distance` and `window`. Rigorous testing would require major changes in the `examples`.