### PR TITLE
Resolve GCC compiler warning in arm_divide_q15()

### DIFF
--- a/Source/FastMathFunctions/arm_divide_q15.c
+++ b/Source/FastMathFunctions/arm_divide_q15.c
@@ -74,11 +74,11 @@ arm_status arm_divide_q15(q15_t numerator,
   {
      if (sign)
      {
-        *quotient = 0x8000;
+        *quotient = -32768;
      }
      else
      {
-        *quotient = 0x7FFF;
+        *quotient = 32767;
      }
      return(ARM_MATH_NANINF);
   }


### PR DESCRIPTION
Replaces the hex constants in `arm_divide_q15()` with their decimal equivalents to prevent GCC from reporting an integer overflow warning (see #159). This occurs because `0x8000` is treated as a positive integer when the 2's complement representation of `-32768` was originally intended.