### PR TITLE
Fix GCC errors with pendantic flag enabled

### DIFF
--- a/Source/TransformFunctions/arm_cfft_init_f16.c
+++ b/Source/TransformFunctions/arm_cfft_init_f16.c
@@ -99,7 +99,7 @@ arm_status arm_cfft_init_##LEN##_f16(                                  \
     status=arm_cfft_radix4by2_rearrange_twiddles_##LENTWIDDLE##_f16(S);\
                                                                        \
     return (status);                                                   \
-};
+}
 
 #else
 
@@ -126,7 +126,7 @@ arm_status arm_cfft_init_##LEN##_f16(arm_cfft_instance_f16 * S)                 
         FFTINIT(f16,LEN);                                                       \
                                                                                 \
         return (status);                                                        \
-};
+}
 
 
 #endif /* #if defined(ARM_FLOAT16_SUPPORTED) */
@@ -144,7 +144,7 @@ arm_status arm_cfft_init_##LEN##_f16(arm_cfft_instance_f16 * S)                 
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(4096,4096);
+CFFTINIT_F16(4096,4096)
 
 /**
   @brief         Initialization function for the cfft f16 function with 2048 samples
@@ -157,7 +157,7 @@ CFFTINIT_F16(4096,4096);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(2048,1024);
+CFFTINIT_F16(2048,1024)
 
 
 /**
@@ -171,7 +171,7 @@ CFFTINIT_F16(2048,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(1024,1024);
+CFFTINIT_F16(1024,1024)
 
 
 /**
@@ -185,7 +185,7 @@ CFFTINIT_F16(1024,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(512,256);
+CFFTINIT_F16(512,256)
 
 
 /**
@@ -199,7 +199,7 @@ CFFTINIT_F16(512,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(256,256);
+CFFTINIT_F16(256,256)
 
 
 /**
@@ -213,7 +213,7 @@ CFFTINIT_F16(256,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(128,64);
+CFFTINIT_F16(128,64)
 
 
 /**
@@ -227,7 +227,7 @@ CFFTINIT_F16(128,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(64,64);
+CFFTINIT_F16(64,64)
  
 
 /**
@@ -241,7 +241,7 @@ CFFTINIT_F16(64,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(32,16);
+CFFTINIT_F16(32,16)
  
 
 /**
@@ -255,7 +255,7 @@ CFFTINIT_F16(32,16);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F16(16,16);
+CFFTINIT_F16(16,16)
 
 
 /**

--- a/Source/TransformFunctions/arm_cfft_init_f32.c
+++ b/Source/TransformFunctions/arm_cfft_init_f32.c
@@ -95,7 +95,7 @@ arm_status arm_cfft_init_##LEN##_f32(                                           
     status=arm_cfft_radix4by2_rearrange_twiddles_##LENTWIDDLE##_f32(S);         \
                                                                                 \
     return (status);                                                            \
-};
+}
 
 #else
 
@@ -119,7 +119,7 @@ arm_status arm_cfft_init_##LEN##_f32(arm_cfft_instance_f32 * S)\
         FFTINIT(f32,LEN);                                      \
                                                                \
         return (status);                                       \
-};
+}
 
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */
 
@@ -134,7 +134,7 @@ arm_status arm_cfft_init_##LEN##_f32(arm_cfft_instance_f32 * S)\
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(4096,4096);
+CFFTINIT_F32(4096,4096)
 
 
 /**
@@ -148,7 +148,7 @@ CFFTINIT_F32(4096,4096);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(2048,1024);
+CFFTINIT_F32(2048,1024)
 
 
 /**
@@ -162,7 +162,7 @@ CFFTINIT_F32(2048,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(1024,1024);
+CFFTINIT_F32(1024,1024)
 
 
 /**
@@ -176,7 +176,7 @@ CFFTINIT_F32(1024,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(512,256);
+CFFTINIT_F32(512,256)
 
 
 /**
@@ -190,7 +190,7 @@ CFFTINIT_F32(512,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(256,256);
+CFFTINIT_F32(256,256)
 
 
 /**
@@ -204,7 +204,7 @@ CFFTINIT_F32(256,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(128,64);
+CFFTINIT_F32(128,64)
 
 
 /**
@@ -218,7 +218,7 @@ CFFTINIT_F32(128,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(64,64);
+CFFTINIT_F32(64,64)
  
 
 /**
@@ -232,7 +232,7 @@ CFFTINIT_F32(64,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(32,16);
+CFFTINIT_F32(32,16)
 
 
 /**
@@ -246,7 +246,7 @@ CFFTINIT_F32(32,16);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F32(16,16);
+CFFTINIT_F32(16,16)
 
 
 /**

--- a/Source/TransformFunctions/arm_cfft_init_f64.c
+++ b/Source/TransformFunctions/arm_cfft_init_f64.c
@@ -70,7 +70,7 @@ arm_status arm_cfft_init_##LEN##_f64(arm_cfft_instance_f64 * S)\
         FFTINIT(f64,LEN);                                   \
                                                                \
         return (status);                                       \
-};
+}
 
 /**
   @brief         Initialization function for the cfft f64 function with 4096 samples
@@ -83,7 +83,7 @@ arm_status arm_cfft_init_##LEN##_f64(arm_cfft_instance_f64 * S)\
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(4096);
+CFFTINIT_F64(4096)
 
 /**
   @brief         Initialization function for the cfft f64 function with 2048 samples
@@ -96,7 +96,7 @@ CFFTINIT_F64(4096);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(2048);
+CFFTINIT_F64(2048)
  
 
 /**
@@ -110,7 +110,7 @@ CFFTINIT_F64(2048);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(1024);
+CFFTINIT_F64(1024)
 
 /**
   @brief         Initialization function for the cfft f64 function with 512 samples
@@ -123,7 +123,7 @@ CFFTINIT_F64(1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(512);
+CFFTINIT_F64(512)
 
 /**
   @brief         Initialization function for the cfft f64 function with 256 samples
@@ -136,7 +136,7 @@ CFFTINIT_F64(512);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(256);
+CFFTINIT_F64(256)
 
 /**
   @brief         Initialization function for the cfft f64 function with 128 samples
@@ -149,7 +149,7 @@ CFFTINIT_F64(256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(128);
+CFFTINIT_F64(128)
 
 /**
   @brief         Initialization function for the cfft f64 function with 64 samples
@@ -162,7 +162,7 @@ CFFTINIT_F64(128);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(64);
+CFFTINIT_F64(64)
 
 /**
   @brief         Initialization function for the cfft f64 function with 32 samples
@@ -175,7 +175,7 @@ CFFTINIT_F64(64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(32);
+CFFTINIT_F64(32)
 
 /**
   @brief         Initialization function for the cfft f64 function with 16 samples
@@ -188,7 +188,7 @@ CFFTINIT_F64(32);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_F64(16);
+CFFTINIT_F64(16)
 
 /**
   @brief         Generic initialization function for the cfft f64 function

--- a/Source/TransformFunctions/arm_cfft_init_q15.c
+++ b/Source/TransformFunctions/arm_cfft_init_q15.c
@@ -94,7 +94,7 @@ arm_status arm_cfft_init_##LEN##_q15(                                  \
     status=arm_cfft_radix4by2_rearrange_twiddles_##LENTWIDDLE##_q15(S);\
                                                                        \
     return (status);                                                   \
-};
+}
 
 
 #else
@@ -119,7 +119,7 @@ arm_status arm_cfft_init_##LEN##_q15(arm_cfft_instance_q15 * S)\
         FFTINIT(q15,LEN);                                      \
                                                                \
         return (status);                                       \
-};
+}
 
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */
 
@@ -136,7 +136,7 @@ arm_status arm_cfft_init_##LEN##_q15(arm_cfft_instance_q15 * S)\
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(4096,4096);
+CFFTINIT_Q15(4096,4096)
 
 /**
   @brief         Initialization function for the cfft q15 function for 2048 samples
@@ -149,7 +149,7 @@ CFFTINIT_Q15(4096,4096);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(2048,1024);
+CFFTINIT_Q15(2048,1024)
 
 /**
   @brief         Initialization function for the cfft q15 function for 1024 samples
@@ -162,7 +162,7 @@ CFFTINIT_Q15(2048,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(1024,1024);
+CFFTINIT_Q15(1024,1024)
 
 /**
   @brief         Initialization function for the cfft q15 function for 512 samples
@@ -175,7 +175,7 @@ CFFTINIT_Q15(1024,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(512,256);
+CFFTINIT_Q15(512,256)
 
 /**
   @brief         Initialization function for the cfft q15 function for 256 samples
@@ -188,7 +188,7 @@ CFFTINIT_Q15(512,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(256,256);
+CFFTINIT_Q15(256,256)
 
 /**
   @brief         Initialization function for the cfft q15 function for 128 samples
@@ -201,7 +201,7 @@ CFFTINIT_Q15(256,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(128,64);
+CFFTINIT_Q15(128,64)
 
 /**
   @brief         Initialization function for the cfft q15 function for 64 samples
@@ -214,7 +214,7 @@ CFFTINIT_Q15(128,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(64,64);
+CFFTINIT_Q15(64,64)
 
 /**
   @brief         Initialization function for the cfft q15 function for 32 samples
@@ -227,7 +227,7 @@ CFFTINIT_Q15(64,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(32,16);
+CFFTINIT_Q15(32,16)
 
 /**
   @brief         Initialization function for the cfft q15 function for 16 samples
@@ -240,7 +240,7 @@ CFFTINIT_Q15(32,16);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q15(16,16);
+CFFTINIT_Q15(16,16)
 
 /**
   @brief         Generic initialization function for the cfft q15 function

--- a/Source/TransformFunctions/arm_cfft_init_q31.c
+++ b/Source/TransformFunctions/arm_cfft_init_q31.c
@@ -95,7 +95,7 @@ arm_status arm_cfft_init_##LEN##_q31(                                \
     status=arm_cfft_radix4by2_rearrange_twiddles_##LENTWIDDLE##_q31(S);\
                                                                      \
     return (status);                                                 \
-};
+}
 
 
 
@@ -121,7 +121,7 @@ arm_status arm_cfft_init_##LEN##_q31(arm_cfft_instance_q31 * S)\
         FFTINIT(q31,LEN);                                      \
                                                                \
         return (status);                                       \
-};
+}
 
 
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */
@@ -137,7 +137,7 @@ arm_status arm_cfft_init_##LEN##_q31(arm_cfft_instance_q31 * S)\
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(4096,4096);
+CFFTINIT_Q31(4096,4096)
 
 /**
   @brief         Initialization function for the cfft q31 function for 2048 samples
@@ -150,7 +150,7 @@ CFFTINIT_Q31(4096,4096);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(2048,1024);
+CFFTINIT_Q31(2048,1024)
 
 /**
   @brief         Initialization function for the cfft q31 function for 1024 samples
@@ -163,7 +163,7 @@ CFFTINIT_Q31(2048,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(1024,1024);
+CFFTINIT_Q31(1024,1024)
 
 /**
   @brief         Initialization function for the cfft q31 function for 512 samples
@@ -176,7 +176,7 @@ CFFTINIT_Q31(1024,1024);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(512,256);
+CFFTINIT_Q31(512,256)
 
 /**
   @brief         Initialization function for the cfft q31 function for 256 samples
@@ -189,7 +189,7 @@ CFFTINIT_Q31(512,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(256,256);
+CFFTINIT_Q31(256,256)
 
 /**
   @brief         Initialization function for the cfft q31 function for 128 samples
@@ -202,7 +202,7 @@ CFFTINIT_Q31(256,256);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(128,64);
+CFFTINIT_Q31(128,64)
 
 /**
   @brief         Initialization function for the cfft q31 function for 64 samples
@@ -215,7 +215,7 @@ CFFTINIT_Q31(128,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(64,64);
+CFFTINIT_Q31(64,64)
 
 /**
   @brief         Initialization function for the cfft q31 function for 32 samples
@@ -228,7 +228,7 @@ CFFTINIT_Q31(64,64);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(32,16);
+CFFTINIT_Q31(32,16)
 
 /**
   @brief         Initialization function for the cfft q31 function for 16 samples
@@ -241,7 +241,7 @@ CFFTINIT_Q31(32,16);
                 Other versions can still initialize directly the data structure using 
                 variables declared in arm_const_structs.h
  */
-CFFTINIT_Q31(16,16);
+CFFTINIT_Q31(16,16)
 
 /**
   @brief         Generic initialization function for the cfft q31 function

--- a/Source/TransformFunctions/arm_mfcc_init_f16.c
+++ b/Source/TransformFunctions/arm_mfcc_init_f16.c
@@ -204,7 +204,7 @@ arm_status arm_mfcc_init_##LEN##_f16(            \
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(32);
+MFCC_INIT_F16(32)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 64 samples MFCC
@@ -233,7 +233,7 @@ MFCC_INIT_F16(32);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(64);
+MFCC_INIT_F16(64)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 128 samples MFCC
@@ -262,7 +262,7 @@ MFCC_INIT_F16(64);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(128);
+MFCC_INIT_F16(128)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 256 samples MFCC
@@ -291,7 +291,7 @@ MFCC_INIT_F16(128);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(256);
+MFCC_INIT_F16(256)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 512 samples MFCC
@@ -320,7 +320,7 @@ MFCC_INIT_F16(256);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(512);
+MFCC_INIT_F16(512)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 1024 samples MFCC
@@ -349,7 +349,7 @@ MFCC_INIT_F16(512);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(1024);
+MFCC_INIT_F16(1024)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 2048 samples MFCC
@@ -378,7 +378,7 @@ MFCC_INIT_F16(1024);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(2048);
+MFCC_INIT_F16(2048)
 
 /**
   @brief         Initialization of the MFCC F16 instance structure for 4096 samples MFCC
@@ -407,7 +407,7 @@ MFCC_INIT_F16(2048);
                    The folder Scripts is containing a Python script that can be used
                    to generate the filter, dct and window arrays.
 */
-MFCC_INIT_F16(4096);
+MFCC_INIT_F16(4096)
 
 #endif /* defined(ARM_FLOAT16_SUPPORTED) */
 /**

--- a/Source/TransformFunctions/arm_mfcc_init_f32.c
+++ b/Source/TransformFunctions/arm_mfcc_init_f32.c
@@ -204,7 +204,7 @@ arm_status arm_mfcc_init_##LEN##_f32(              \
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(32);
+MFCC_INIT_F32(32)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 64 samples MFCC
@@ -233,7 +233,7 @@ MFCC_INIT_F32(32);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(64);
+MFCC_INIT_F32(64)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 128 samples MFCC
@@ -262,7 +262,7 @@ MFCC_INIT_F32(64);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(128);
+MFCC_INIT_F32(128)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 256 samples MFCC
@@ -291,7 +291,7 @@ MFCC_INIT_F32(128);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(256);
+MFCC_INIT_F32(256)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 512 samples MFCC
@@ -320,7 +320,7 @@ MFCC_INIT_F32(256);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(512);
+MFCC_INIT_F32(512)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 1024 samples MFCC
@@ -349,7 +349,7 @@ MFCC_INIT_F32(512);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(1024);
+MFCC_INIT_F32(1024)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 2048 samples MFCC
@@ -378,7 +378,7 @@ MFCC_INIT_F32(1024);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(2048);
+MFCC_INIT_F32(2048)
 
 /**
   @brief         Initialization of the MFCC F32 instance structure for 4096 samples MFCC
@@ -407,7 +407,7 @@ MFCC_INIT_F32(2048);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_F32(4096);
+MFCC_INIT_F32(4096)
 
 /**
   @} end of MFCCF32 group

--- a/Source/TransformFunctions/arm_mfcc_init_q15.c
+++ b/Source/TransformFunctions/arm_mfcc_init_q15.c
@@ -203,7 +203,7 @@ arm_status arm_mfcc_init_##LEN##_q15(             \
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(32);
+MFCC_INIT_Q15(32)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 64 samples MFCC
@@ -232,7 +232,7 @@ MFCC_INIT_Q15(32);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(64);
+MFCC_INIT_Q15(64)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 128 samples MFCC
@@ -261,7 +261,7 @@ MFCC_INIT_Q15(64);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(128);
+MFCC_INIT_Q15(128)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 256 samples MFCC
@@ -290,7 +290,7 @@ MFCC_INIT_Q15(128);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(256);
+MFCC_INIT_Q15(256)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 512 samples MFCC
@@ -319,7 +319,7 @@ MFCC_INIT_Q15(256);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(512);
+MFCC_INIT_Q15(512)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 1024 samples MFCC
@@ -348,7 +348,7 @@ MFCC_INIT_Q15(512);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(1024);
+MFCC_INIT_Q15(1024)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 2048 samples MFCC
@@ -377,7 +377,7 @@ MFCC_INIT_Q15(1024);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(2048);
+MFCC_INIT_Q15(2048)
 
 /**
   @brief         Initialization of the MFCC Q15 instance structure for 4096 samples MFCC
@@ -406,7 +406,7 @@ MFCC_INIT_Q15(2048);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q15(4096);
+MFCC_INIT_Q15(4096)
 
 /**
   @} end of MFCCQ15 group

--- a/Source/TransformFunctions/arm_mfcc_init_q31.c
+++ b/Source/TransformFunctions/arm_mfcc_init_q31.c
@@ -205,7 +205,7 @@ arm_status arm_mfcc_init_##LEN##_q31(             \
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(32);
+MFCC_INIT_Q31(32)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 64 sample MFCC
@@ -234,7 +234,7 @@ MFCC_INIT_Q31(32);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(64);
+MFCC_INIT_Q31(64)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 128 sample MFCC
@@ -263,7 +263,7 @@ MFCC_INIT_Q31(64);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(128);
+MFCC_INIT_Q31(128)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 256 sample MFCC
@@ -292,7 +292,7 @@ MFCC_INIT_Q31(128);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(256);
+MFCC_INIT_Q31(256)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 512 sample MFCC
@@ -321,7 +321,7 @@ MFCC_INIT_Q31(256);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(512);
+MFCC_INIT_Q31(512)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 1024 sample MFCC
@@ -350,7 +350,7 @@ MFCC_INIT_Q31(512);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(1024);
+MFCC_INIT_Q31(1024)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 2048 sample MFCC
@@ -379,7 +379,7 @@ MFCC_INIT_Q31(1024);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(2048);
+MFCC_INIT_Q31(2048)
 
 /**
   @brief         Initialization of the MFCC Q31 instance structure for 4096 sample MFCC
@@ -408,7 +408,7 @@ MFCC_INIT_Q31(2048);
                    The folder Scripts is containing a Python script which can be used
                    to generate the filter, dct and window arrays.
  */
-MFCC_INIT_Q31(4096);
+MFCC_INIT_Q31(4096)
 
 /**
   @} end of MFCCQ31 group

--- a/Source/TransformFunctions/arm_rfft_init_q15.c
+++ b/Source/TransformFunctions/arm_rfft_init_q15.c
@@ -131,7 +131,7 @@ arm_status arm_rfft_init_##LEN##_q15( arm_rfft_instance_q15 * S,  \
 
  */
 
-RFFTINIT_Q15(8192,4096,1);
+RFFTINIT_Q15(8192,4096,1)
 
 /**
   @brief         Initialization function for the 4096 pt Q15 real FFT.
@@ -155,7 +155,7 @@ RFFTINIT_Q15(8192,4096,1);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(4096,2048,2);
+RFFTINIT_Q15(4096,2048,2)
 
 /**
   @brief         Initialization function for the 2048 pt Q15 real FFT.
@@ -179,7 +179,7 @@ RFFTINIT_Q15(4096,2048,2);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(2048,1024,4);
+RFFTINIT_Q15(2048,1024,4)
 
 /**
   @brief         Initialization function for the 1024 pt Q15 real FFT.
@@ -203,7 +203,7 @@ RFFTINIT_Q15(2048,1024,4);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(1024,512,8);
+RFFTINIT_Q15(1024,512,8)
 
 /**
   @brief         Initialization function for the 512 pt Q15 real FFT.
@@ -227,7 +227,7 @@ RFFTINIT_Q15(1024,512,8);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(512,256,16);
+RFFTINIT_Q15(512,256,16)
 
 /**
   @brief         Initialization function for the 256 pt Q15 real FFT.
@@ -251,7 +251,7 @@ RFFTINIT_Q15(512,256,16);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(256,128,32);
+RFFTINIT_Q15(256,128,32)
 
 /**
   @brief         Initialization function for the 128 pt Q15 real FFT.
@@ -275,7 +275,7 @@ RFFTINIT_Q15(256,128,32);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(128,64,64);
+RFFTINIT_Q15(128,64,64)
 
 /**
   @brief         Initialization function for the 64 pt Q15 real FFT.
@@ -299,7 +299,7 @@ RFFTINIT_Q15(128,64,64);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(64,32,128);
+RFFTINIT_Q15(64,32,128)
 
 /**
   @brief         Initialization function for the 32 pt Q15 real FFT.
@@ -323,7 +323,7 @@ RFFTINIT_Q15(64,32,128);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q15(32,16,256);
+RFFTINIT_Q15(32,16,256)
 
 /**
   @brief         Generic initialization function for the Q15 RFFT/RIFFT.

--- a/Source/TransformFunctions/arm_rfft_init_q31.c
+++ b/Source/TransformFunctions/arm_rfft_init_q31.c
@@ -128,7 +128,7 @@ arm_status arm_rfft_init_##LEN##_q31( arm_rfft_instance_q31 * S,  \
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(8192,4096,1);
+RFFTINIT_Q31(8192,4096,1)
 
 /**
   @brief         Initialization function for the 4096 pt Q31 real FFT.
@@ -152,7 +152,7 @@ RFFTINIT_Q31(8192,4096,1);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(4096,2048,2);
+RFFTINIT_Q31(4096,2048,2)
 
 /**
   @brief         Initialization function for the 2048 pt Q31 real FFT.
@@ -176,7 +176,7 @@ RFFTINIT_Q31(4096,2048,2);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(2048,1024,4);
+RFFTINIT_Q31(2048,1024,4)
 
 /**
   @brief         Initialization function for the 1024 pt Q31 real FFT.
@@ -200,7 +200,7 @@ RFFTINIT_Q31(2048,1024,4);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(1024,512,8);
+RFFTINIT_Q31(1024,512,8)
 
 /**
   @brief         Initialization function for the 512 pt Q31 real FFT.
@@ -224,7 +224,7 @@ RFFTINIT_Q31(1024,512,8);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(512,256,16);
+RFFTINIT_Q31(512,256,16)
 
 /**
   @brief         Initialization function for the 256 pt Q31 real FFT.
@@ -248,7 +248,7 @@ RFFTINIT_Q31(512,256,16);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(256,128,32);
+RFFTINIT_Q31(256,128,32)
 
 /**
   @brief         Initialization function for the 128 pt Q31 real FFT.
@@ -272,7 +272,7 @@ RFFTINIT_Q31(256,128,32);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(128,64,64);
+RFFTINIT_Q31(128,64,64)
 
 /**
   @brief         Initialization function for the 64 pt Q31 real FFT.
@@ -296,7 +296,7 @@ RFFTINIT_Q31(128,64,64);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(64,32,128);
+RFFTINIT_Q31(64,32,128)
 
 /**
   @brief         Initialization function for the 32 pt Q31 real FFT.
@@ -320,7 +320,7 @@ RFFTINIT_Q31(64,32,128);
   @par
                    This function also initializes Twiddle factor table.
  */
-RFFTINIT_Q31(32,16,256);
+RFFTINIT_Q31(32,16,256)
 
 
 /**


### PR DESCRIPTION
Fixes the GCC errors that are generated when compiling CMSIS-DSP with the `-pendantic` flag (see #160). The errors were caused by some minor ISO non-compliant use of semicolons in certain macro definitions.