### PR TITLE
Fix using NEON intrinsics when AUTOVECTORIZE is set

### DIFF
--- a/Source/SVMFunctions/arm_svm_polynomial_predict_f32.c
+++ b/Source/SVMFunctions/arm_svm_polynomial_predict_f32.c
@@ -301,7 +301,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f32(
 }
 
 #else
-#if defined(ARM_MATH_NEON)
+#if defined(ARM_MATH_NEON) && !defined(ARM_MATH_AUTOVECTORIZE)
 ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f32(
     const arm_svm_polynomial_instance_f32 *S,
     const float32_t * in,


### PR DESCRIPTION
Ran into an issue where even with AUTOVECTORIZE set, NEON intrinsics were still being compiled (namely, `vfmaq` which isn't available on Cortex-A9). This simply adds the guard to properly prevent that.

This fixes #190 