### PR TITLE
Fix intrinsic collisions due to NEON flag usage

### DIFF
--- a/Include/arm_math_types.h
+++ b/Include/arm_math_types.h
@@ -112,13 +112,8 @@ extern "C"
 #include <limits.h>
 
 /* evaluate ARM DSP feature */
-/* Intrinsincs are defined in CMSIS Core that is not available when
- * targeting Cortex-A or Cortex-R
- */
-#if !defined(ARM_MATH_NEON) && !defined(ARM_MATH_NEON_EXPERIMENTAL)
 #if (defined (__ARM_FEATURE_DSP) && (__ARM_FEATURE_DSP == 1))
   #define ARM_MATH_DSP                   1
-#endif
 #endif
 
 #if defined(ARM_MATH_NEON)


### PR DESCRIPTION
See #220 for details.

Essentially there's function/macro definition collisions that occur due to already being defined in `cmsis_gcc.h`. 

I'm not entirely sure if this is the right way to fix this issue, since there's a note about CMSIS/Core not being available on Cortex-A/R, ...except that it seems to be the only way to build right now on a baremetal/non-hosted system, since otherwise there's complaints about `cmsis_compiler.h` missing in the same file.