### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/Documentation/Doxygen/src/code_size.md
+++ b/Documentation/Doxygen/src/code_size.md
@@ -1,6 +1,6 @@
 # Code size {#dsppp_code_size}
 
-It was explained in previous sections that types `Vector<T,NB1>` and `Vector<T,NB2>` are considered as different types if `NB1` and `NB2` are differents.
+It was explained in previous sections that types `Vector<T,NB1>` and `Vector<T,NB2>` are considered as different types if `NB1` and `NB2` are different.
 
 A template algorithm is like a code generator that will generate different code for different values of the template arguments : the types.
 

--- a/Documentation/Doxygen/src/history.md
+++ b/Documentation/Doxygen/src/history.md
@@ -1,5 +1,5 @@
 # Revision History {#rev_hist}
 
-CMSIS-DSP version is offically updated upon releases of the [CMSIS-DSP pack](https://www.keil.arm.com/packs/cmsis-dsp-arm/versions/).
+CMSIS-DSP version is officially updated upon releases of the [CMSIS-DSP pack](https://www.keil.arm.com/packs/cmsis-dsp-arm/versions/).
 
 The table below provides information about the changes delivered with specific versions of CMSIS-DSP.

--- a/Documentation/Doxygen/src/mainpage.md
+++ b/Documentation/Doxygen/src/mainpage.md
@@ -75,7 +75,7 @@ The table below explains the content of **ARM::CMSIS-DSP** pack.
  Directory                             | Description
 :--------------------------------------|:------------------------------------------------------
  📂 ComputeLibrary                     | Small Neon kernels when building on Cortex-A
- 📂 Documentation                      | Folder with this CMSIS-DSP documenation
+ 📂 Documentation                      | Folder with this CMSIS-DSP documentation
  📂 Example                            | Example projects demonstrating the usage of the library functions
  📂 Include                            | Include files for using and building the lib
  📂 PrivateInclude                     | Private include files for building the lib
@@ -163,7 +163,7 @@ All algorithms are compared with a double precision reference and the different 
 
 As consequence, the small differences that may exists between the different architecture implementations should be too small to have any practical consequences.
 
-Also, when targetting Helium or Neon, some functions have  different APIs.
+Also, when targeting Helium or Neon, some functions have  different APIs.
 
 ### Different API for Helium
 * Biquad F32 and F16 : A different init function must be used

--- a/Documentation/Doxygen/src/matrix.md
+++ b/Documentation/Doxygen/src/matrix.md
@@ -123,7 +123,7 @@ In addition to the vector operations `+`,`-` and `*`, matrixes are supporting mo
 * `dot` for vector / matrix products
 * `diagonal` to create a diagonal matrix from a vector.
 * `identity` to create an identity matrix
-* `tranpose` to create the transposed matrix
+* `transpose` to create the transposed matrix
 * `outer` for the outer product of two vectors
 
 ### dot

--- a/Documentation/Doxygen/src/vector.md
+++ b/Documentation/Doxygen/src/vector.md
@@ -69,7 +69,7 @@ You can then operate with this virtual vector:
 subD = subD + 2.0f;
 ```
 
-If you display the vector `d`, you'll see that `2.0f` has been added to all elements starting from the 2rd one.
+If you display the vector `d`, you'll see that `2.0f` has been added to all elements starting from the 2nd one.
 
 `VectorView` do not own their memory. It is owned by the original vector. 
 

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -2,7 +2,7 @@
 
 CMSIS-DSP Documentation in HTML format is published online at [https://arm-software.github.io/CMSIS-DSP](https://arm-software.github.io/CMSIS-DSP).
 
-The version drop-down menu there allows to switch between the documentation provided with offical releases and the latest draft documentation for the main branch.
+The version drop-down menu there allows to switch between the documentation provided with official releases and the latest draft documentation for the main branch.
 
 The documentation source is maintained in `Documentation/Doxygen/` folder as a mixture of markdown and doxygen formats. Component source files, templates and examples may also contribute information that gets integrated into the final documentation.
 

--- a/Examples/ARM/arm_bayes_example/arm_bayes_example.ini
+++ b/Examples/ARM/arm_bayes_example/arm_bayes_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_class_marks_example.ini
+   INCLUDE arm_class_marks_example.ini
 
 */
 

--- a/Examples/ARM/arm_class_marks_example/arm_class_marks_example.ini
+++ b/Examples/ARM/arm_class_marks_example/arm_class_marks_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_class_marks_example.ini
+   INCLUDE arm_class_marks_example.ini
 
 */
 

--- a/Examples/ARM/arm_convolution_example/arm_convolution_example.ini
+++ b/Examples/ARM/arm_convolution_example/arm_convolution_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_convolution_example.ini
+   INCLUDE arm_convolution_example.ini
 
 */
 

--- a/Examples/ARM/arm_convolution_example/math_helper.c
+++ b/Examples/ARM/arm_convolution_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example.ini
+++ b/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_dotproduct_example.ini
+   INCLUDE arm_dotproduct_example.ini
 
 */
 

--- a/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example_f32.c
+++ b/Examples/ARM/arm_dotproduct_example/arm_dotproduct_example_f32.c
@@ -140,7 +140,7 @@ float32_t  refDotProdOut = 5.9273644806352142;
 * Declare Global variables
 * ------------------------------------------------------------------- */
 float32_t multOutput[MAX_BLOCKSIZE];  /* Intermediate output */
-float32_t testOutput;  /* Final ouput */
+float32_t testOutput;  /* Final output */
 
 arm_status status;   /* Status of the example */
 

--- a/Examples/ARM/arm_fft_bin_example/arm_fft_bin_example.ini
+++ b/Examples/ARM/arm_fft_bin_example/arm_fft_bin_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_fft_bin_example.ini
+   INCLUDE arm_fft_bin_example.ini
 
 */
 

--- a/Examples/ARM/arm_fir_example/arm_fir_example.ini
+++ b/Examples/ARM/arm_fir_example/arm_fir_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_fir_lpf_example.ini
+   INCLUDE arm_fir_lpf_example.ini
 
 */
 

--- a/Examples/ARM/arm_fir_example/math_helper.c
+++ b/Examples/ARM/arm_fir_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example.ini
+++ b/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_geq_5band_example.ini
+   INCLUDE arm_geq_5band_example.ini
 
 */
 

--- a/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example_q31.c
+++ b/Examples/ARM/arm_graphic_equalizer_example/arm_graphic_equalizer_example_q31.c
@@ -73,7 +73,7 @@
  * \par
  * \image html GEQ_allbandresponse.gif
  * \par
- * Each 4th order filter has 10 coefficents for a grand total of 950 different filter
+ * Each 4th order filter has 10 coefficients for a grand total of 950 different filter
  * coefficients that must be tabulated. The input and output data is in Q31 format.
  * For better noise performance, the two low frequency bands are implemented using the high
  * precision 32x64-bit Biquad filters. The remaining 3 high frequency bands use standard

--- a/Examples/ARM/arm_graphic_equalizer_example/math_helper.c
+++ b/Examples/ARM/arm_graphic_equalizer_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example.ini
+++ b/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_linear_interp_example.ini
+   INCLUDE arm_linear_interp_example.ini
 
 */
 

--- a/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example_f32.c
+++ b/Examples/ARM/arm_linear_interp_example/arm_linear_interp_example_f32.c
@@ -56,14 +56,14 @@
  *
  * \par Block Diagram:
  * \par
- * \image html linearInterpExampleMethod1.gif "Method 1: Sine caluclation using fast math"
+ * \image html linearInterpExampleMethod1.gif "Method 1: Sine calculation using fast math"
  * \par
- * \image html linearInterpExampleMethod2.gif "Method 2: Sine caluclation using interpolation function"
+ * \image html linearInterpExampleMethod2.gif "Method 2: Sine calculation using interpolation function"
  *
  * \par Variables Description:
  * \par
  * \li \c testInputSin_f32         points to the input values for sine calculation
- * \li \c testRefSinOutput32_f32   points to the reference values caculated from sin() matlab function
+ * \li \c testRefSinOutput32_f32   points to the reference values calculated from sin() matlab function
  * \li \c testOutput               points to output buffer calculation from cubic interpolation
  * \li \c testLinIntOutput         points to output buffer calculation from linear interpolation
  * \li \c snr1                     Signal to noise ratio for reference and cubic interpolation output
@@ -136,7 +136,7 @@ float32_t testLinIntOutput[TEST_LENGTH_SAMPLES];
 extern const float arm_linear_interep_table[1884];
 
 /* ----------------------------------------------------------------------
-* Global Variables for caluclating SNR's for Method1 & Method 2
+* Global Variables for calculating SNR's for Method1 & Method 2
 * ------------------------------------------------------------------- */
 float32_t snr1;
 float32_t snr2;

--- a/Examples/ARM/arm_linear_interp_example/math_helper.c
+++ b/Examples/ARM/arm_linear_interp_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_matrix_example/arm_matrix_example.ini
+++ b/Examples/ARM/arm_matrix_example/arm_matrix_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_matrix_example.ini
+   INCLUDE arm_matrix_example.ini
 
 */
 

--- a/Examples/ARM/arm_matrix_example/arm_matrix_example_f32.c
+++ b/Examples/ARM/arm_matrix_example/arm_matrix_example_f32.c
@@ -47,7 +47,7 @@
  *
  * \par Description:
  * \par
- * Demonstrates the use of Matrix Transpose, Matrix Muliplication, and Matrix Inverse
+ * Demonstrates the use of Matrix Transpose, Matrix Multiplication, and Matrix Inverse
  * functions to apply least squares fitting to input data. Least squares fitting is
  * the procedure for finding the best-fitting curve that minimizes the sum of the
  * squares of the offsets (least square error) from a given set of data.
@@ -96,7 +96,7 @@
 #define SNR_THRESHOLD   77
 
 /* --------------------------------------------------------------------------------
-* Test input data(Cycles) taken from FIR Q15 module for differant cases of blockSize
+* Test input data(Cycles) taken from FIR Q15 module for different cases of blockSize
 * and tapSize
 * --------------------------------------------------------------------------------- */
 
@@ -132,7 +132,7 @@ float32_t ATMAI_f32[16];
 float32_t X_f32[4];
 
 /* ----------------------------------------------------------------------
-* Reference ouput buffer C1, C2, C3 and C4 taken from MATLAB
+* Reference output buffer C1, C2, C3 and C4 taken from MATLAB
 * ------------------------------------------------------------------- */
 const float32_t xRef_f32[4] = {73.0, 8.0, 21.25, 2.875};
 

--- a/Examples/ARM/arm_matrix_example/math_helper.c
+++ b/Examples/ARM/arm_matrix_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_signal_converge_example/arm_signal_converge_example.ini
+++ b/Examples/ARM/arm_signal_converge_example/arm_signal_converge_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_signal_converge_example.ini
+   INCLUDE arm_signal_converge_example.ini
 
 */
 

--- a/Examples/ARM/arm_signal_converge_example/math_helper.c
+++ b/Examples/ARM/arm_signal_converge_example/math_helper.c
@@ -50,12 +50,12 @@
 #include "math_helper.h"
 
 /**
- * @brief  Caluclation of SNR
+ * @brief  Calculation of SNR
  * @param[in]  pRef 	Pointer to the reference buffer
  * @param[in]  pTest	Pointer to the test buffer
  * @param[in]  buffSize	total number of samples
  * @return     SNR
- * The function Caluclates signal to noise ratio for the reference output
+ * The function Calculates signal to noise ratio for the reference output
  * and test output
  */
 
@@ -258,10 +258,10 @@ void arm_provide_guard_bits_q7 (q7_t * input_buf,
 
 
 /**
- * @brief  Caluclates number of guard bits
+ * @brief  Calculates number of guard bits
  * @param[in]  num_adds 	number of additions
  * @return guard bits
- * The function Caluclates the number of guard bits
+ * The function Calculates the number of guard bits
  * depending on the numtaps
  */
 

--- a/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example.ini
+++ b/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_sin_cos_example.ini
+   INCLUDE arm_sin_cos_example.ini
 
 */
 

--- a/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example_f32.c
+++ b/Examples/ARM/arm_sin_cos_example/arm_sin_cos_example_f32.c
@@ -46,12 +46,12 @@
  *
  * \par Description:
  * \par
- * Demonstrates the Pythagorean trignometric identity with the use of Cosine, Sine, Vector
+ * Demonstrates the Pythagorean trigonometric identity with the use of Cosine, Sine, Vector
  * Multiplication, and Vector Addition functions.
  *
  * \par Algorithm:
  * \par
- * Mathematically, the Pythagorean trignometric identity is defined by the following equation:
+ * Mathematically, the Pythagorean trigonometric identity is defined by the following equation:
  *  <pre>sin(x) * sin(x) + cos(x) * cos(x) = 1</pre>
  * where \c x is the angle in radians.
  *

--- a/Examples/ARM/arm_svm_example/arm_svm_example.ini
+++ b/Examples/ARM/arm_svm_example/arm_svm_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_class_marks_example.ini
+   INCLUDE arm_class_marks_example.ini
 
 */
 

--- a/Examples/ARM/arm_variance_example/arm_variance_example.ini
+++ b/Examples/ARM/arm_variance_example/arm_variance_example.ini
@@ -3,7 +3,7 @@
 
    The file can be executed in the following way:
    1) manually from uVision command window (in debug mode) using command:
-   INCLUIDE arm_variance_example.ini
+   INCLUDE arm_variance_example.ini
 
 */
 

--- a/Examples/cmsis_build/RTE/Device/SSE-300-MPS3/region_defs.h
+++ b/Examples/cmsis_build/RTE/Device/SSE-300-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/Examples/cmsis_build/RTE/Device/SSE-300-MPS3/region_limits.h
+++ b/Examples/cmsis_build/RTE/Device/SSE-300-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/Include/arm_helium_utils.h
+++ b/Include/arm_helium_utils.h
@@ -115,7 +115,7 @@ __STATIC_FORCEINLINE float16x8_t __mve_cmplx_sum_intra_vec_f16(
     uint32_t    tmp = 0;
 
     vecTmp = (float16x8_t) vrev64q_s32((int32x4_t) vecIn);
-    // TO TRACK : using canonical addition leads to unefficient code generation for f16
+    // TO TRACK : using canonical addition leads to inefficient code generation for f16
     // vecTmp = vecTmp + vecAccCpx0;
     /*
      * Compute
@@ -135,7 +135,7 @@ __STATIC_FORCEINLINE float16x8_t __mve_cmplx_sum_intra_vec_f16(
      */
     vecOut = vaddq_f16(vecOut, vecTmp);
     /*
-     * Cmplx sum is in 4rd & 5th f16 elt
+     * Cmplx sum is in 4th & 5th f16 elt
      * return full vector
      */
     return vecOut;
@@ -155,7 +155,7 @@ __STATIC_FORCEINLINE void mve_cmplx_sum_intra_vec_f16(
 {
     float16x8_t   vecOut = __mve_cmplx_sum_intra_vec_f16(vecIn);
     /*
-     * Cmplx sum is in 4rd & 5th f16 elt
+     * Cmplx sum is in 4th & 5th f16 elt
      * use 32-bit extraction
      */
     *(float32_t *) pOut = ((float32x4_t) vecOut)[2];

--- a/Include/arm_math_types.h
+++ b/Include/arm_math_types.h
@@ -81,7 +81,7 @@ extern "C"
 #endif
 
 
-/* Included for instrinsics definitions */
+/* Included for intrinsics definitions */
 #if defined (_MSC_VER ) 
 #include <stdint.h>
 #define __STATIC_FORCEINLINE static __forceinline

--- a/Include/dsp/distance_functions.h
+++ b/Include/dsp/distance_functions.h
@@ -197,7 +197,7 @@ float64_t arm_cosine_distance_f64(const float64_t *pA,const float64_t *pB, uint3
  *
  * When the function is computing x log (x / y) with x 0 and y 0,
  * it will compute the right value (0) but a division per zero will occur
- * and shoudl be ignored in client code.
+ * and should be ignored in client code.
  *
  * @param[in]    pA         First vector
  * @param[in]    pB         Second vector

--- a/Include/dsp/distance_functions_f16.h
+++ b/Include/dsp/distance_functions_f16.h
@@ -140,7 +140,7 @@ float16_t arm_cosine_distance_f16(const float16_t *pA,const float16_t *pB, uint3
  *
  * When the function is computing x log (x / y) with x 0 and y 0,
  * it will compute the right value (0) but a division per zero will occur
- * and shoudl be ignored in client code.
+ * and should be ignored in client code.
  *
  * @param[in]    pA         First vector
  * @param[in]    pB         Second vector

--- a/Include/dsp/interpolation_functions.h
+++ b/Include/dsp/interpolation_functions.h
@@ -124,7 +124,7 @@ extern "C"
   /**
    * @brief Processing function for the floating-point cubic spline interpolation.
    * @param[in]  S          points to an instance of the floating-point spline structure.
-   * @param[in]  xq         points to the x values ot the interpolated data points.
+   * @param[in]  xq         points to the x values of the interpolated data points.
    * @param[out] pDst       points to the block of output data.
    * @param[in]  blockSize  number of samples of output data.
    */

--- a/Include/dsp/none.h
+++ b/Include/dsp/none.h
@@ -1,6 +1,6 @@
 /******************************************************************************
  * @file     none.h
- * @brief    Intrinsincs when no DSP extension available
+ * @brief    Intrinsics when no DSP extension available
  * @version  V1.9.0
  * @date     20. July 2020
  ******************************************************************************/

--- a/Include/dsp/support_functions.h
+++ b/Include/dsp/support_functions.h
@@ -503,13 +503,13 @@ const q7_t * pSrc,
  *
  *
  * @param[in]    *in           Array of input values.
- * @param[in]    *weigths      Weights
+ * @param[in]    *weights      Weights
  * @param[in]    blockSize     Number of samples in the input array.
  * @return Weighted average
  *
  */
 float32_t arm_weighted_average_f32(const float32_t *in
-  , const float32_t *weigths
+  , const float32_t *weights
   , uint32_t blockSize);
 
 

--- a/Include/dsp/support_functions_f16.h
+++ b/Include/dsp/support_functions_f16.h
@@ -115,12 +115,12 @@ void arm_f16_to_float(const float16_t * pSrc, float32_t * pDst, uint32_t blockSi
 /**
  * @brief Weighted average
  * @param[in]    *in           Array of input values.
- * @param[in]    *weigths      Weights
+ * @param[in]    *weights      Weights
  * @param[in]    blockSize     Number of samples in the input array.
  * @return Weighted average
  */
 float16_t arm_weighted_average_f16(const float16_t *in
-  , const float16_t *weigths
+  , const float16_t *weights
   , uint32_t blockSize);
 
 

--- a/Ne10/CMSIS_NE10_fft_common_variables.h
+++ b/Ne10/CMSIS_NE10_fft_common_variables.h
@@ -36,7 +36,7 @@
 #define CMSIS_NE10_FFT_COMMON_VARIBLES_H
 
 ///////////////////////////
-// common varibles
+// common variables
 ///////////////////////////
 
 /* Twiddles used in Radix-8 FFT */

--- a/Ne10/CMSIS_NE10_types.h
+++ b/Ne10/CMSIS_NE10_types.h
@@ -52,7 +52,7 @@
 
 /**
  * @TODO Move the definition of NE10_UNROLL_LEVEL to cmake configuration files.
- * Macro NE10_UNROLL_LEVEL controls algorithm of FFT funtions.
+ * Macro NE10_UNROLL_LEVEL controls algorithm of FFT functions.
  * When NE10_UNROLL_LEVEL == 0, complex FFT performs radix-4 x2 per loop.
  * When NE10_UNROLL_LEVEL == 1, complex FFT performs radix-4 x4 per loop.
  */

--- a/Ne10/NE10_fft_float16.neonintrinsic.c
+++ b/Ne10/NE10_fft_float16.neonintrinsic.c
@@ -26,7 +26,7 @@
  */
 
 /*
- * CMSIS-DSP f16 implementtaion based upon the Ne10 f32 one
+ * CMSIS-DSP f16 implementation based upon the Ne10 f32 one
  */
 
 #include <arm_neon.h>

--- a/PythonWrapper/docs/source/api.rst
+++ b/PythonWrapper/docs/source/api.rst
@@ -183,7 +183,7 @@ You convert back to a complex format to compare with scipy::
 Matrix
 ******
 
-For matrix, the instance variables are masked by the Python API. We decided that for matrix only there was no use for having the CMSIS-DSP instance visibles since they contain the same information as the numpy array (samples and dimension).
+For matrix, the instance variables are masked by the Python API. We decided that for matrix only there was no use for having the CMSIS-DSP instance visible since they contain the same information as the numpy array (samples and dimension).
 
 So to use a CMSIS-DSP matrix function, it is very simple::
 

--- a/PythonWrapper/examples/example.py
+++ b/PythonWrapper/examples/example.py
@@ -60,7 +60,7 @@ biquadQ31 = dsp.arm_biquad_casd_df1_inst_q31()
 numStages=3
 state=np.zeros(numStages*4)
 # For use in CMSIS, denominator coefs must be negated
-# and first a0 coef wihich is always 1 must be removed
+# and first a0 coef which is always 1 must be removed
 coefs=np.reshape(np.hstack((sos[:,:3],-sos[:,4:])),15)
 coefs = coefs / 4.0 
 coefsQ31 = toQ31(coefs)

--- a/PythonWrapper/examples/example_1_5.py
+++ b/PythonWrapper/examples/example_1_5.py
@@ -124,7 +124,7 @@ rows,columns = m.shape
 # wrapper to allocate two temporary buffers.
 # Like that you can check you have dimensionned the arrays in the
 # right way.
-# The content of the temporary buffers is not accesible from the
+# The content of the temporary buffers is not accessible from the
 # Python API. tmpa and tmpb are not modified.
 tmpa=np.zeros(rows)
 tmpb=np.zeros(rows)

--- a/PythonWrapper_README.md
+++ b/PythonWrapper_README.md
@@ -184,7 +184,7 @@ You convert back to a complex format to compare with scipy:
 
 ## Matrix 
 
-For matrix, the instance variables are masked by the Python API. We decided that for matrix only there was no use for having the [CMSIS-DSP](https://github.com/ARM-software/CMSIS-DSP) instance visibles since they contain the same information as the numpy array (samples and dimension).
+For matrix, the instance variables are masked by the Python API. We decided that for matrix only there was no use for having the [CMSIS-DSP](https://github.com/ARM-software/CMSIS-DSP) instance visible since they contain the same information as the numpy array (samples and dimension).
 
 So to use a [CMSIS-DSP](https://github.com/ARM-software/CMSIS-DSP) matrix function, it is very simple:
 

--- a/Scripts/mfccdata.py
+++ b/Scripts/mfccdata.py
@@ -1,7 +1,7 @@
 ###########################################
 # Project:      CMSIS DSP Library
 # Title:        mfccdata.py
-# Description:  Generation of MFCC arays for the MFCC C init function
+# Description:  Generation of MFCC arrays for the MFCC C init function
 # 
 # $Date:        07 September 2021
 # $Revision:    V1.10.0

--- a/Source/ComplexMathFunctions/ComplexMathFunctions.c
+++ b/Source/ComplexMathFunctions/ComplexMathFunctions.c
@@ -1,7 +1,7 @@
 /* ----------------------------------------------------------------------
  * Project:      CMSIS DSP Library
  * Title:        CompexMathFunctions.c
- * Description:  Combination of all comlex math function source files.
+ * Description:  Combination of all complex math function source files.
  *
  * $Date:        18. March 2019
  * $Revision:    V1.0.0

--- a/Source/FastMathFunctions/arm_sqrt_q31.c
+++ b/Source/FastMathFunctions/arm_sqrt_q31.c
@@ -91,7 +91,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_sqrt_q31(
     temp = 0x30000000 - temp; 
     var1 = ((q63_t) var1 * temp) >> 29;
 
-    /* 3nd iteration */
+    /* 3rd iteration */
     temp = ((q63_t) var1 * var1) >> 28;
     temp = ((q63_t) number * temp) >> 31;
     temp = 0x30000000 - temp; 

--- a/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q31.c
+++ b/Source/FilteringFunctions/arm_biquad_cascade_df1_fast_q31.c
@@ -50,7 +50,7 @@
                    These intermediate results are added to a 2.30 accumulator.
                    Finally, the accumulator is saturated and converted to a 1.31 result.
                    The fast version has the same overflow behavior as the standard version and provides less precision since it discards the low 32 bits of each multiplication result.
-                   In order to avoid overflows completely the input signal must be scaled down by two bits and lie in the range [-0.25 +0.25). Use the intialization function
+                   In order to avoid overflows completely the input signal must be scaled down by two bits and lie in the range [-0.25 +0.25). Use the initialization function
                    arm_biquad_cascade_df1_init_q31() to initialize filter structure.
   @remark
                    Refer to \ref arm_biquad_cascade_df1_q31() for a slower implementation of this function

--- a/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
+++ b/Source/FilteringFunctions/arm_conv_fast_opt_q15.c
@@ -156,7 +156,7 @@ ARM_DSP_ATTRIBUTE void arm_conv_fast_opt_q15(
     k--;
   }
 
-  /* Initialze temporary scratch pointer */
+  /* Initialize temporary scratch pointer */
   pScr1 = pScratch1;
 
   /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -195,10 +195,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_fast_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -314,10 +314,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_fast_opt_q15(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_conv_opt_q15.c
+++ b/Source/FilteringFunctions/arm_conv_opt_q15.c
@@ -152,7 +152,7 @@ ARM_DSP_ATTRIBUTE void arm_conv_opt_q15(
     k--;
   }
 
-  /* Initialze temporary scratch pointer */
+  /* Initialize temporary scratch pointer */
   pScr1 = pScratch1;
 
   /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -191,10 +191,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -310,10 +310,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_opt_q15(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_conv_opt_q7.c
+++ b/Source/FilteringFunctions/arm_conv_opt_q7.c
@@ -200,10 +200,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_opt_q7(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -312,10 +312,10 @@ ARM_DSP_ATTRIBUTE void arm_conv_opt_q7(
   /* Calculate convolution for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
+++ b/Source/FilteringFunctions/arm_conv_partial_fast_opt_q15.c
@@ -166,7 +166,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_fast_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -206,10 +206,10 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_fast_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -326,10 +326,10 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_fast_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
+++ b/Source/FilteringFunctions/arm_conv_partial_opt_q15.c
@@ -167,7 +167,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_opt_q15(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Assuming scratch1 buffer is aligned by 32-bit */
@@ -207,10 +207,10 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_opt_q15(
 
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
       acc1 = 0;
       acc2 = 0;
@@ -326,10 +326,10 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_opt_q15(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
+++ b/Source/FilteringFunctions/arm_conv_partial_opt_q7.c
@@ -150,7 +150,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_opt_q7(
       k--;
     }
 
-    /* Initialze temporary scratch pointer */
+    /* Initialize temporary scratch pointer */
     pScr1 = pScratch1;
 
     /* Fill (srcBLen - 1U) zeros in scratch buffer */
@@ -331,10 +331,10 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_opt_q7(
     /* Calculate convolution for remaining samples of Bigger length sequence */
     while (blkCnt > 0)
     {
-      /* Initialze temporary scratch pointer as scratch1 */
+      /* Initialize temporary scratch pointer as scratch1 */
       pScr1 = pScratch1;
 
-      /* Clear Accumlators */
+      /* Clear Accumulators */
       acc0 = 0;
 
       tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_correlate_f16.c
+++ b/Source/FilteringFunctions/arm_correlate_f16.c
@@ -1034,7 +1034,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f16(
   /* So srcBLen is always considered as shorter or equal to srcALen */
   /* But CORR(x, y) is reverse of CORR(y, x) */
   /* So, when srcBLen > srcALen, output pointer is made to point to the end of the output buffer */
-  /* and a varaible, inv is set to 1 */
+  /* and a variable, inv is set to 1 */
   /* If lengths are not equal then zero pad has to be done to  make the two
    * inputs of same length. But to improve the performance, we assume zeroes
    * in the output instead of zero padding either of the the inputs*/
@@ -1042,7 +1042,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f16(
    * starting of the output buffer */
   /* If srcALen < srcBLen, (srcALen - srcBLen) zeroes has to included in the
    * ending of the output buffer */
-  /* Once the zero padding is done the remaining of the output is calcualted
+  /* Once the zero padding is done the remaining of the output is calculated
    * using convolution but with the shorter signal time shifted. */
 
   /* Calculate the length of the remaining sequence */

--- a/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/Source/FilteringFunctions/arm_correlate_f32.c
@@ -1025,7 +1025,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f32(
   /* So srcBLen is always considered as shorter or equal to srcALen */
   /* But CORR(x, y) is reverse of CORR(y, x) */
   /* So, when srcBLen > srcALen, output pointer is made to point to the end of the output buffer */
-  /* and a varaible, inv is set to 1 */
+  /* and a variable, inv is set to 1 */
   /* If lengths are not equal then zero pad has to be done to  make the two
    * inputs of same length. But to improve the performance, we assume zeroes
    * in the output instead of zero padding either of the the inputs*/
@@ -1033,7 +1033,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f32(
    * starting of the output buffer */
   /* If srcALen < srcBLen, (srcALen - srcBLen) zeroes has to included in the
    * ending of the output buffer */
-  /* Once the zero padding is done the remaining of the output is calcualted
+  /* Once the zero padding is done the remaining of the output is calculated
    * using convolution but with the shorter signal time shifted. */
 
   /* Calculate the length of the remaining sequence */

--- a/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
+++ b/Source/FilteringFunctions/arm_correlate_fast_opt_q15.c
@@ -173,10 +173,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_fast_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -292,10 +292,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_fast_opt_q15(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_correlate_opt_q15.c
+++ b/Source/FilteringFunctions/arm_correlate_opt_q15.c
@@ -168,10 +168,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_opt_q15(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -289,10 +289,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_opt_q15(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_correlate_opt_q7.c
+++ b/Source/FilteringFunctions/arm_correlate_opt_q7.c
@@ -225,10 +225,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_opt_q7(
 
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
     acc1 = 0;
     acc2 = 0;
@@ -339,10 +339,10 @@ ARM_DSP_ATTRIBUTE void arm_correlate_opt_q7(
   /* Calculate correlation for remaining samples of Bigger length sequence */
   while (blkCnt > 0)
   {
-    /* Initialze temporary scratch pointer as scratch1 */
+    /* Initialize temporary scratch pointer as scratch1 */
     pScr1 = pScratch1;
 
-    /* Clear Accumlators */
+    /* Clear Accumulators */
     acc0 = 0;
 
     tapCnt = (srcBLen) >> 1U;

--- a/Source/FilteringFunctions/arm_correlate_q15.c
+++ b/Source/FilteringFunctions/arm_correlate_q15.c
@@ -825,7 +825,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q15(
   /* So srcBLen is always considered as shorter or equal to srcALen */
   /* But CORR(x, y) is reverse of CORR(y, x) */
   /* So, when srcBLen > srcALen, output pointer is made to point to the end of the output buffer */
-  /* and a varaible, inv is set to 1 */
+  /* and a variable, inv is set to 1 */
   /* If lengths are not equal then zero pad has to be done to  make the two
    * inputs of same length. But to improve the performance, we include zeroes
    * in the output instead of zero padding either of the the inputs*/
@@ -833,7 +833,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q15(
    * starting of the output buffer */
   /* If srcALen < srcBLen, (srcALen - srcBLen) zeroes has to included in the
    * ending of the output buffer */
-  /* Once the zero padding is done the remaining of the output is calcualted
+  /* Once the zero padding is done the remaining of the output is calculated
    * using convolution but with the shorter signal time shifted. */
 
   /* Calculate the length of the remaining sequence */

--- a/Source/FilteringFunctions/arm_correlate_q31.c
+++ b/Source/FilteringFunctions/arm_correlate_q31.c
@@ -801,7 +801,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q31(
   /* So srcBLen is always considered as shorter or equal to srcALen */
   /* But CORR(x, y) is reverse of CORR(y, x) */
   /* So, when srcBLen > srcALen, output pointer is made to point to the end of the output buffer */
-  /* and a varaible, inv is set to 1 */
+  /* and a variable, inv is set to 1 */
   /* If lengths are not equal then zero pad has to be done to  make the two
    * inputs of same length. But to improve the performance, we include zeroes
    * in the output instead of zero padding either of the the inputs*/
@@ -809,7 +809,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q31(
    * starting of the output buffer */
   /* If srcALen < srcBLen, (srcALen - srcBLen) zeroes has to included in the
    * ending of the output buffer */
-  /* Once the zero padding is done the remaining of the output is calcualted
+  /* Once the zero padding is done the remaining of the output is calculated
    * using correlation but with the shorter signal time shifted. */
 
   /* Calculate the length of the remaining sequence */

--- a/Source/FilteringFunctions/arm_correlate_q7.c
+++ b/Source/FilteringFunctions/arm_correlate_q7.c
@@ -925,7 +925,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q7(
   /* So srcBLen is always considered as shorter or equal to srcALen */
   /* But CORR(x, y) is reverse of CORR(y, x) */
   /* So, when srcBLen > srcALen, output pointer is made to point to the end of the output buffer */
-  /* and a varaible, inc is set to -1 */
+  /* and a variable, inc is set to -1 */
   /* If lengths are not equal then zero pad has to be done to  make the two
    * inputs of same length. But to improve the performance, we include zeroes
    * in the output instead of zero padding either of the the inputs*/
@@ -933,7 +933,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_q7(
    * starting of the output buffer */
   /* If srcALen < srcBLen, (srcALen - srcBLen) zeroes has to included in the
    * ending of the output buffer */
-  /* Once the zero padding is done the remaining of the output is calcualted
+  /* Once the zero padding is done the remaining of the output is calculated
    * using convolution but with the shorter signal time shifted. */
 
   /* Calculate the length of the remaining sequence */

--- a/Source/FilteringFunctions/arm_fir_interpolate_f32.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_f32.c
@@ -156,7 +156,7 @@ static void arm_fir_interpolate2_f32_mve(
      */
     pStateCurnt = S->pState + (phaseLen - 1U);
     /*
-     * Total number of intput samples
+     * Total number of input samples
      */
     blkCnt = blockSize;
     /*
@@ -288,7 +288,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_f32(
      */
     pStateCurnt = S->pState + (phaseLen - 1U);
     /*
-     * Total number of intput samples
+     * Total number of input samples
      */
     blkCnt = blockSize;
     /*
@@ -1169,7 +1169,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_f32(
   /* pStateCur points to the location where the new input data should be written */
   pStateCur = S->pState + (phaseLen - 1U);
 
-  /* Total number of intput samples */
+  /* Total number of input samples */
   blkCnt = blockSize;
 
   /* Loop over the blockSize. */

--- a/Source/FilteringFunctions/arm_fir_interpolate_q15.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_q15.c
@@ -85,7 +85,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_q15(
      */
     pStateCurnt = S->pState + ((q15_t) phaseLen - 1);
     /*
-     * Total number of intput samples
+     * Total number of input samples
      */
     blkCnt = blockSize;
     /*
@@ -693,7 +693,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_q15(
   /* pStateCur points to the location where the new input data should be written */
   pStateCur = S->pState + (phaseLen - 1U);
 
-  /* Total number of intput samples */
+  /* Total number of input samples */
   blkCnt = blockSize;
 
   /* Loop over the blockSize. */

--- a/Source/FilteringFunctions/arm_fir_interpolate_q31.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_q31.c
@@ -82,7 +82,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_q31(
      */
     pStateCurnt = S->pState + ((q31_t) phaseLen - 1);
     /*
-     * Total number of intput samples
+     * Total number of input samples
      */
     blkCnt = blockSize;
     /*
@@ -692,7 +692,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_q31(
   /* pStateCur points to the location where the new input data should be written */
   pStateCur = S->pState + (phaseLen - 1U);
 
-  /* Total number of intput samples */
+  /* Total number of input samples */
   blkCnt = blockSize;
 
   /* Loop over the blockSize. */

--- a/Source/FilteringFunctions/arm_fir_lattice_f32.c
+++ b/Source/FilteringFunctions/arm_fir_lattice_f32.c
@@ -58,7 +58,7 @@
       y[n] = fM[n]
   </pre>
   @par
-                   <code>pCoeffs</code> points to tha array of reflection coefficients of size <code>numStages</code>.
+                   <code>pCoeffs</code> points to the array of reflection coefficients of size <code>numStages</code>.
                    Reflection Coefficients are stored in the following order.
   @par
   <pre>

--- a/Source/FilteringFunctions/arm_iir_lattice_f32.c
+++ b/Source/FilteringFunctions/arm_iir_lattice_f32.c
@@ -125,7 +125,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_f32(
 {       
         float32_t *pState = S->pState;                   /* State pointer */
         float32_t *pStateCur;                            /* State current pointer */
-        float32_t acc;                                   /* Accumlator */
+        float32_t acc;                                   /* Accumulator */
         float32_t fnext1, fnext2, gcurr1, gnext;         /* Temporary variables for lattice stages */
         float32_t *px1, *px2, *pk, *pv;                  /* Temporary pointers for state and coef */
         uint32_t numStages = S->numStages;               /* Number of stages */
@@ -305,7 +305,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_f32(
   }
 
   /* Processing is complete. Now copy last S->numStages samples to start of the buffer
-     for the preperation of next frame process */
+     for the preparation of next frame process */
 
   /* Points to the start of the state buffer */
   pStateCur = &S->pState[0];

--- a/Source/FilteringFunctions/arm_iir_lattice_q15.c
+++ b/Source/FilteringFunctions/arm_iir_lattice_q15.c
@@ -62,7 +62,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q15(
         q15_t *pState = S->pState;                     /* State pointer */
         q15_t *pStateCur;                              /* State current pointer */
         q31_t fcurr, fnext = 0, gcurr = 0, gnext;      /* Temporary variables for lattice stages */
-        q63_t acc;                                     /* Accumlator */
+        q63_t acc;                                     /* Accumulator */
         q15_t *px1, *px2, *pk, *pv;                    /* Temporary pointers for state and coef */
         uint32_t numStages = S->numStages;             /* Number of stages */
         uint32_t blkCnt, tapCnt;                       /* Temporary variables for counts */
@@ -139,7 +139,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q15(
       /* write gN-1(n) into state for next sample processing */
       *px2++ = (q15_t) gnext1;
 
-      /* Process sample for 3nd, 7th ...taps */
+      /* Process sample for 3rd, 7th ...taps */
       /* Read gN-3(n-1) from state buffer */
       gcurr = *px1++;
       /* Process sample for 3rd, 7th .. taps */
@@ -262,7 +262,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q15(
   }
 
   /* Processing is complete. Now copy last S->numStages samples to start of the buffer
-     for the preperation of next frame process */
+     for the preparation of next frame process */
 
   /* Points to the start of the state buffer */
   pStateCur = &S->pState[0];
@@ -369,7 +369,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q15(
   }
 
   /* Processing is complete. Now copy last S->numStages samples to start of the buffer
-     for the preperation of next frame process */
+     for the preparation of next frame process */
 
   /* Points to the start of the state buffer */
   pStateCur = &S->pState[0];

--- a/Source/FilteringFunctions/arm_iir_lattice_q31.c
+++ b/Source/FilteringFunctions/arm_iir_lattice_q31.c
@@ -61,7 +61,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q31(
         q31_t *pState = S->pState;                       /* State pointer */
         q31_t *pStateCur;                                /* State current pointer */
         q31_t fcurr, fnext = 0, gcurr = 0, gnext;        /* Temporary variables for lattice stages */
-        q63_t acc;                                       /* Accumlator */
+        q63_t acc;                                       /* Accumulator */
         q31_t *px1, *px2, *pk, *pv;                      /* Temporary pointers for state and coef */
         uint32_t numStages = S->numStages;               /* Number of stages */
         uint32_t blkCnt, tapCnt;                         /* Temporary variables for counts */
@@ -132,7 +132,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q31(
       /* write gN-1(n) into state for next sample processing */
       *px2++ = gnext;
 
-      /* Process sample for 3nd, 7th ...taps */
+      /* Process sample for 3rd, 7th ...taps */
       /* Read gN-3(n-1) from state buffer */
       gcurr = *px1++;
       /* Process sample for 3rd, 7th .. taps */
@@ -223,7 +223,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q31(
   }
 
   /* Processing is complete. Now copy last S->numStages samples to start of the buffer
-     for the preperation of next frame process */
+     for the preparation of next frame process */
 
   /* Points to the start of the state buffer */
   pStateCur = &S->pState[0];
@@ -329,7 +329,7 @@ ARM_DSP_ATTRIBUTE void arm_iir_lattice_q31(
   }
 
   /* Processing is complete. Now copy last S->numStages samples to start of the buffer
-     for the preperation of next frame process */
+     for the preparation of next frame process */
 
   /* Points to the start of the state buffer */
   pStateCur = &S->pState[0];

--- a/Source/FilteringFunctions/arm_levinson_durbin_q31.c
+++ b/Source/FilteringFunctions/arm_levinson_durbin_q31.c
@@ -78,7 +78,7 @@ __STATIC_FORCEINLINE q31_t divide(q31_t n, q31_t d)
   (void)status;
   
   // d is used instead of l
-  // So we will need to substract to 2 instead of 1.
+  // So we will need to subtract to 2 instead of 1.
   r = mul32x16(d,inverse);
   r = TWO_Q30 - (r << shift);
   r = mul32x16(r, inverse);

--- a/Source/FilteringFunctions/arm_lms_f32.c
+++ b/Source/FilteringFunctions/arm_lms_f32.c
@@ -39,7 +39,7 @@
   LMS filters use a gradient descent method in which the filter coefficients are updated based on the instantaneous error signal.
   Adaptive filters are often used in communication systems, equalizers, and noise removal.
   The CMSIS DSP Library contains LMS filter functions that operate on Q15, Q31, and floating-point data types.
-  The library also contains normalized LMS filters in which the filter coefficient adaptation is indepedent of the level of the input signal.
+  The library also contains normalized LMS filters in which the filter coefficient adaptation is independent of the level of the input signal.
 
   An LMS filter consists of two components as shown below.
   The first component is a standard transversal or FIR filter.

--- a/Source/FilteringFunctions/arm_lms_norm_q15.c
+++ b/Source/FilteringFunctions/arm_lms_norm_q15.c
@@ -58,7 +58,7 @@
                    result in 1.15 format.
  @par
   	               In this filter, filter coefficients are updated for each sample and the
-                   updation of filter cofficients are saturted.
+                   updation of filter coefficients are saturted.
  */
 
 ARM_DSP_ATTRIBUTE void arm_lms_norm_q15(

--- a/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -58,7 +58,7 @@
                    The output signal and error signal are in 1.31 format.
  @par
   	               In this filter, filter coefficients are updated for each sample and the
-                   updation of filter cofficients are saturted.
+                   updation of filter coefficients are saturted.
  */
 
 ARM_DSP_ATTRIBUTE void arm_lms_norm_q31(

--- a/Source/FilteringFunctions/arm_lms_q15.c
+++ b/Source/FilteringFunctions/arm_lms_q15.c
@@ -55,7 +55,7 @@
                    Lastly, the accumulator is saturated to yield a result in 1.15 format.
   @par
                    In this filter, filter coefficients are updated for each sample and
-                   the updation of filter cofficients are saturted.
+                   the updation of filter coefficients are saturted.
  */
 
 ARM_DSP_ATTRIBUTE void arm_lms_q15(

--- a/Source/FilteringFunctions/arm_lms_q31.c
+++ b/Source/FilteringFunctions/arm_lms_q31.c
@@ -59,7 +59,7 @@
                    The output signal and error signal are in 1.31 format.
  @par
                    In this filter, filter coefficients are updated for each sample and
-                   the updation of filter cofficients are saturted.
+                   the updation of filter coefficients are saturted.
  */
 
 ARM_DSP_ATTRIBUTE void arm_lms_q31(

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_f16.c
@@ -784,7 +784,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           /* Reading imaginary part of complex matrix B */
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a0 * c0;
           sumImag += b0 * c0;
 
@@ -792,7 +792,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b0 * d0;
           sumImag += a0 * d0;
 
@@ -804,7 +804,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -812,7 +812,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 
@@ -821,7 +821,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           b0 = *(pIn1 + 1U);
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a0 * c0;
           sumImag += b0 * c0;
 
@@ -829,7 +829,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b0 * d0;
           sumImag += a0 * d0;
 
@@ -840,7 +840,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -848,7 +848,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 
@@ -875,7 +875,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -883,7 +883,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f16(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_f32.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_f32.c
@@ -1262,7 +1262,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           /* Reading imaginary part of complex matrix B */
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a0 * c0;
           sumImag += b0 * c0;
 
@@ -1270,7 +1270,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b0 * d0;
           sumImag += a0 * d0;
 
@@ -1282,7 +1282,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -1290,7 +1290,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 
@@ -1299,7 +1299,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           b0 = *(pIn1 + 1U);
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a0 * c0;
           sumImag += b0 * c0;
 
@@ -1307,7 +1307,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b0 * d0;
           sumImag += a0 * d0;
 
@@ -1318,7 +1318,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -1326,7 +1326,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 
@@ -1353,7 +1353,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += a1 * c1;
           sumImag += b1 * c1;
 
@@ -1361,7 +1361,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_f32(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= b1 * d1;
           sumImag += a1 * d1;
 

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_q15.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_q15.c
@@ -464,7 +464,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           pSourceA = read_q15x2_ia (&pInA);
           pSourceB = read_q15x2_ia (&pInB);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else
@@ -478,7 +478,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           pSourceA = read_q15x2_ia (&pInA);
           pSourceB = read_q15x2_ia (&pInB);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else
@@ -497,7 +497,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           c = *pInB;
           d = *(pInB + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q31_t) a *c;
           sumImag += (q31_t) a *d;
           sumReal -= (q31_t) b *d;
@@ -513,7 +513,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           /* update pointer */
           pInA += 4U;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q31_t) a * c;
           sumImag += (q31_t) a * d;
           sumReal -= (q31_t) b * d;
@@ -537,7 +537,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           pSourceA = read_q15x2_ia (&pInA);
           pSourceB = read_q15x2_ia (&pInB);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
 #ifdef ARM_MATH_BIG_ENDIAN
           prod1 = -__SMUSD(pSourceA, pSourceB);
 #else
@@ -555,7 +555,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q15(
           c = *pInB++;
           d = *pInB++;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q31_t) a * c;
           sumImag += (q31_t) a * d;
           sumReal -= (q31_t) b * d;

--- a/Source/MatrixFunctions/arm_mat_cmplx_mult_q31.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_mult_q31.c
@@ -918,7 +918,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           /* Reading imaginary part of complex matrix B */
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q63_t) a0 * c0;
           sumImag += (q63_t) b0 * c0;
 
@@ -926,7 +926,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= (q63_t) b0 * d0;
           sumImag += (q63_t) a0 * d0;
 
@@ -938,7 +938,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q63_t) a1 * c1;
           sumImag += (q63_t) b1 * c1;
 
@@ -946,7 +946,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= (q63_t) b1 * d1;
           sumImag += (q63_t) a1 * d1;
 
@@ -955,7 +955,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           b0 = *(pIn1 + 1U);
           d0 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q63_t) a0 * c0;
           sumImag += (q63_t) b0 * c0;
 
@@ -963,7 +963,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= (q63_t) b0 * d0;
           sumImag += (q63_t) a0 * d0;
 
@@ -974,7 +974,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q63_t) a1 * c1;
           sumImag += (q63_t) b1 * c1;
 
@@ -982,7 +982,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= (q63_t) b1 * d1;
           sumImag += (q63_t) a1 * d1;
 
@@ -1009,7 +1009,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           b1 = *(pIn1 + 1U);
           d1 = *(pIn2 + 1U);
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal += (q63_t) a1 * c1;
           sumImag += (q63_t) b1 * c1;
 
@@ -1017,7 +1017,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_cmplx_mult_q31(
           pIn1 += 2U;
           pIn2 += 2 * numColsB;
 
-          /* Multiply and Accumlates */
+          /* Multiply and Accumulates */
           sumReal -= (q63_t) b1 * d1;
           sumImag += (q63_t) a1 * d1;
 

--- a/Source/MatrixFunctions/arm_mat_cmplx_trans_f32.c
+++ b/Source/MatrixFunctions/arm_mat_cmplx_trans_f32.c
@@ -35,7 +35,7 @@
 /**
   @defgroup MatrixComplexTrans Complex Matrix Transpose
 
-  Tranposes a complex matrix.
+  Transposes a complex matrix.
 
   Transposing an <code>M x N</code> matrix flips it around the center diagonal and results in an <code>N x M</code> matrix.
  

--- a/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
+++ b/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
@@ -412,7 +412,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_mult_opt_q31(
         while (row > 0u) {
             /*
              * For every row wise process, the column loop counter is to be initiated
-             * Compute 2 columns and 2 rows in parrallel
+             * Compute 2 columns and 2 rows in parallel
              */
             col = numColsB >> 1;
             j = 0;

--- a/Source/MatrixFunctions/arm_mat_scale_f32.c
+++ b/Source/MatrixFunctions/arm_mat_scale_f32.c
@@ -189,7 +189,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_scale_f32(
       res = vmulq_f32(vec1, vdupq_n_f32(scale));
       vst1q_f32(pOut, res);
 
-      /* update pointers to process next sampels */
+      /* update pointers to process next samples */
       pIn += 4U;
       pOut += 4U;
 

--- a/Source/MatrixFunctions/arm_mat_scale_q31.c
+++ b/Source/MatrixFunctions/arm_mat_scale_q31.c
@@ -141,7 +141,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_scale_q31(
   uint32_t blkCnt;                               /* Loop counter */
   arm_status status;                             /* Status of matrix scaling */
   int32_t kShift = shift + 1;                    /* Shift to apply after scaling */
-  q31_t in, out;                                 /* Temporary variabels */
+  q31_t in, out;                                 /* Temporary variables */
 
 #ifdef ARM_MATH_MATRIX_CHECK
 

--- a/Source/MatrixFunctions/arm_mat_sub_f32.c
+++ b/Source/MatrixFunctions/arm_mat_sub_f32.c
@@ -36,7 +36,7 @@
   @defgroup MatrixSub Matrix Subtraction
 
   Subtract two matrices.
-  @par Subraction of two 3 x 3 matrices
+  @par Subtraction of two 3 x 3 matrices
   
   \f[
   \begin{pmatrix}

--- a/Source/MatrixFunctions/arm_mat_trans_f32.c
+++ b/Source/MatrixFunctions/arm_mat_trans_f32.c
@@ -35,7 +35,7 @@
 /**
   @defgroup MatrixTrans Matrix Transpose
 
-  Tranposes a matrix.
+  Transposes a matrix.
 
   Transposing an <code>M x N</code> matrix flips it around the center diagonal and results in an <code>N x M</code> matrix.
 

--- a/Source/MatrixFunctions/arm_mat_trans_f64.c
+++ b/Source/MatrixFunctions/arm_mat_trans_f64.c
@@ -35,7 +35,7 @@
 /**
   @defgroup MatrixTrans Matrix Transpose
 
-  Tranposes a matrix.
+  Transposes a matrix.
 
   Transposing an <code>M x N</code> matrix flips it around the center diagonal and results in an <code>N x M</code> matrix.
   \image html MatrixTranspose.gif "Transpose of a 3 x 3 matrix"

--- a/Source/MatrixFunctions/arm_mat_vec_mult_f16.c
+++ b/Source/MatrixFunctions/arm_mat_vec_mult_f16.c
@@ -161,7 +161,7 @@ ARM_DSP_ATTRIBUTE void arm_mat_vec_mult_f16(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2)
     {

--- a/Source/SVMFunctions/arm_svm_linear_predict_f16.c
+++ b/Source/SVMFunctions/arm_svm_linear_predict_f16.c
@@ -70,7 +70,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_linear_predict_f16(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) 
     {

--- a/Source/SVMFunctions/arm_svm_linear_predict_f32.c
+++ b/Source/SVMFunctions/arm_svm_linear_predict_f32.c
@@ -67,7 +67,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_linear_predict_f32(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) 
     {

--- a/Source/SVMFunctions/arm_svm_polynomial_predict_f16.c
+++ b/Source/SVMFunctions/arm_svm_polynomial_predict_f16.c
@@ -97,7 +97,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f16(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float16_t *pInA2, *pInA3;
@@ -193,7 +193,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f16(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float16_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/SVMFunctions/arm_svm_polynomial_predict_f32.c
+++ b/Source/SVMFunctions/arm_svm_polynomial_predict_f32.c
@@ -74,7 +74,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f32(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float32_t *pInA2, *pInA3;
@@ -169,7 +169,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_polynomial_predict_f32(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float32_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/SVMFunctions/arm_svm_rbf_predict_f16.c
+++ b/Source/SVMFunctions/arm_svm_rbf_predict_f16.c
@@ -74,7 +74,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_rbf_predict_f16(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float16_t *pInA2, *pInA3;
@@ -179,7 +179,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_rbf_predict_f16(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float16_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/SVMFunctions/arm_svm_rbf_predict_f32.c
+++ b/Source/SVMFunctions/arm_svm_rbf_predict_f32.c
@@ -71,7 +71,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_rbf_predict_f32(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float32_t *pInA2, *pInA3;
@@ -176,7 +176,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_rbf_predict_f32(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float32_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/SVMFunctions/arm_svm_sigmoid_predict_f16.c
+++ b/Source/SVMFunctions/arm_svm_sigmoid_predict_f16.c
@@ -74,7 +74,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_sigmoid_predict_f16(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float16_t *pInA2, *pInA3;
@@ -169,7 +169,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_sigmoid_predict_f16(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float16_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/SVMFunctions/arm_svm_sigmoid_predict_f32.c
+++ b/Source/SVMFunctions/arm_svm_sigmoid_predict_f32.c
@@ -71,7 +71,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_sigmoid_predict_f32(
     row = numRows;
 
     /*
-     * compute 4 rows in parrallel
+     * compute 4 rows in parallel
      */
     while (row >= 4) {
         const float32_t *pInA2, *pInA3;
@@ -166,7 +166,7 @@ ARM_DSP_ATTRIBUTE void arm_svm_sigmoid_predict_f32(
     }
 
     /*
-     * compute 2 rows in parrallel
+     * compute 2 rows in parallel
      */
     if (row >= 2) {
         float32_t const *pSrcA0Vec, *pSrcA1Vec, *pInVec;

--- a/Source/StatisticsFunctions/arm_absmax_f16.c
+++ b/Source/StatisticsFunctions/arm_absmax_f16.c
@@ -149,7 +149,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_f16(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = ((_Float16)out > 0.0f16) ? out : -(_Float16)out;                                                                             \
   /* Initialize index of extrema value. */                                                                  \
@@ -236,7 +236,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_f16(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (_Float16)fabsf((float32_t)*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_f32.c
+++ b/Source/StatisticsFunctions/arm_absmax_f32.c
@@ -135,7 +135,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_f32(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0.0f) ? out : -out;                                                                             \
   /* Initialize index of extrema value. */                                                                  \
@@ -224,7 +224,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_f32(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabsf(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_f64.c
+++ b/Source/StatisticsFunctions/arm_absmax_f64.c
@@ -58,7 +58,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_f64(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabs(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_f16.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_f16.c
@@ -115,7 +115,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f16(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = ((_Float16)out > 0.0f16) ? out : -(_Float16)out;                                                                             \
                                                                                              \
@@ -192,7 +192,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f16(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (_Float16)fabsf((float32_t)*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_f32.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_f32.c
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f32(
         float32_t cur_absmax, out;                     /* Temporary variables to store the output value. */\
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0.0f) ? out : -out;                                                                             \
                                                                                                             \
@@ -191,7 +191,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f32(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabsf(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_f64.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_f64.c
@@ -64,7 +64,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f64(
     
     
     
-    /* Load first input value that act as reference value for comparision */
+    /* Load first input value that act as reference value for comparison */
 
     
     /* Initialize blkCnt with number of samples */
@@ -122,7 +122,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_f64(
     
     
     
-    /* Load first input value that act as reference value for comparision */
+    /* Load first input value that act as reference value for comparison */
     out = fabs(*pSrc++);
     
     /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_q15.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_q15.c
@@ -93,7 +93,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q15(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                             \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q15_t)__QSUB16(0, out);                                                                           \
                                                                                               \
@@ -169,7 +169,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q15(
         uint32_t blkCnt;                     /* Loop counter */
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q15_t) 0x8000) ? 0x7fff : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_q31.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_q31.c
@@ -92,7 +92,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q31(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q31_t)__QSUB(0, out);                                                                           \
                                                                                               \
@@ -169,7 +169,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q31(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == INT32_MIN) ? INT32_MAX : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmax_no_idx_q7.c
+++ b/Source/StatisticsFunctions/arm_absmax_no_idx_q7.c
@@ -97,7 +97,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q7(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q7_t)__QSUB8(0, out);                                                                           \
                                                                                               \
@@ -174,7 +174,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_no_idx_q7(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q7_t) 0x80) ? (q7_t) 0x7f : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmax_q15.c
+++ b/Source/StatisticsFunctions/arm_absmax_q15.c
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q15(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q15_t)__QSUB16(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -199,7 +199,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q15(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q15_t) 0x8000) ? 0x7fff : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmax_q31.c
+++ b/Source/StatisticsFunctions/arm_absmax_q31.c
@@ -112,7 +112,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q31(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q31_t)__QSUB(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -199,7 +199,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q31(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == INT32_MIN) ? INT32_MAX : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmax_q7.c
+++ b/Source/StatisticsFunctions/arm_absmax_q7.c
@@ -170,7 +170,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q7(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q7_t)__QSUB8(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -257,7 +257,7 @@ ARM_DSP_ATTRIBUTE void arm_absmax_q7(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q7_t) 0x80) ? (q7_t) 0x7f : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_f16.c
+++ b/Source/StatisticsFunctions/arm_absmin_f16.c
@@ -151,7 +151,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_f16(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = ((_Float16)out > 0.0f16) ? out : -(_Float16)out;                                                                             \
   /* Initialize index of extrema value. */                                                                  \
@@ -238,7 +238,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_f16(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (_Float16)fabsf((float32_t)*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_f32.c
+++ b/Source/StatisticsFunctions/arm_absmin_f32.c
@@ -156,7 +156,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_f32(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0.0f) ? out : -out;                                                                             \
   /* Initialize index of extrema value. */                                                                  \
@@ -243,7 +243,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_f32(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabsf(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_f64.c
+++ b/Source/StatisticsFunctions/arm_absmin_f64.c
@@ -56,7 +56,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_f64(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabs(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_f16.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_f16.c
@@ -117,7 +117,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f16(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                           \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = ((_Float16)out > 0.0f16) ? out : -(_Float16)out;                                                                             \
                                                                                               \
@@ -194,7 +194,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f16(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (_Float16)fabsf((float32_t)*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_f32.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_f32.c
@@ -115,7 +115,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f32(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0.0f) ? out : -out;                                                                             \
                                                                                               \
@@ -192,7 +192,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f32(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = fabsf(*pSrc++);
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_f64.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_f64.c
@@ -62,7 +62,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f64(
     
     
     
-    /* Load first input value that act as reference value for comparision */
+    /* Load first input value that act as reference value for comparison */
     
     
     /* Initialize blkCnt with number of samples */
@@ -117,7 +117,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_f64(
     uint32_t blkCnt;                     /* Loop counter */
     
     
-    /* Load first input value that act as reference value for comparision */
+    /* Load first input value that act as reference value for comparison */
     out = fabs(*pSrc++);
     
     /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_q15.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_q15.c
@@ -110,7 +110,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q15(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q15_t)__QSUB16(0, out);                                                                           \
                                                                                              \
@@ -187,7 +187,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q15(
 
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q15_t) 0x8000) ? 0x7fff : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_q31.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_q31.c
@@ -111,7 +111,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q31(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q31_t)__QSUB(0, out);                                                                           \
                                                                                               \
@@ -186,7 +186,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q31(
         q31_t minVal, out;                             /* Temporary variables to store the output value. */
         uint32_t blkCnt;                     /* Loop counter */
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == INT32_MIN) ? INT32_MAX : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_no_idx_q7.c
+++ b/Source/StatisticsFunctions/arm_absmin_no_idx_q7.c
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q7(
         uint32_t blkCnt;                     /* Loop counter */                                   \
                                                                                                             \
                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q7_t)__QSUB8(0, out);                                                                           \
                                                                                                             \
@@ -188,7 +188,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_no_idx_q7(
         uint32_t blkCnt;                     /* Loop counter */
 
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q7_t) 0x80) ? (q7_t) 0x7f : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_q15.c
+++ b/Source/StatisticsFunctions/arm_absmin_q15.c
@@ -145,7 +145,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q15(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q15_t)__QSUB16(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -232,7 +232,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q15(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q15_t) 0x8000) ? 0x7fff : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_q31.c
+++ b/Source/StatisticsFunctions/arm_absmin_q31.c
@@ -146,7 +146,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q31(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q31_t)__QSUB(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -232,7 +232,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q31(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == INT32_MIN) ? INT32_MAX : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_absmin_q7.c
+++ b/Source/StatisticsFunctions/arm_absmin_q7.c
@@ -199,7 +199,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q7(
                                                                                                             \
   /* Initialize index value to zero. */                                                                     \
   outIndex = 0U;                                                                                            \
-  /* Load first input value that act as reference value for comparision */                                  \
+  /* Load first input value that act as reference value for comparison */                                  \
   out = *pSrc++;                                                                                            \
   out = (out > 0) ? out : (q7_t)__QSUB8(0, out);                                                                           \
   /* Initialize index of extrema value. */                                                                  \
@@ -285,7 +285,7 @@ ARM_DSP_ATTRIBUTE void arm_absmin_q7(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = (*pSrc > 0) ? *pSrc : ((*pSrc == (q7_t) 0x80) ? (q7_t) 0x7f : -*pSrc);
   pSrc++;
 

--- a/Source/StatisticsFunctions/arm_max_f16.c
+++ b/Source/StatisticsFunctions/arm_max_f16.c
@@ -154,7 +154,7 @@ ARM_DSP_ATTRIBUTE void arm_max_f16(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/StatisticsFunctions/arm_max_f32.c
+++ b/Source/StatisticsFunctions/arm_max_f32.c
@@ -275,7 +275,7 @@ ARM_DSP_ATTRIBUTE void arm_max_f32(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/StatisticsFunctions/arm_max_f64.c
+++ b/Source/StatisticsFunctions/arm_max_f64.c
@@ -56,7 +56,7 @@ ARM_DSP_ATTRIBUTE void arm_max_f64(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_max_no_idx_f64.c
+++ b/Source/StatisticsFunctions/arm_max_no_idx_f64.c
@@ -62,7 +62,7 @@ ARM_DSP_ATTRIBUTE void arm_max_no_idx_f64(
     
     
     
-    /* Load first input value that act as reference value for comparision */
+    /* Load first input value that act as reference value for comparison */
     
     
     /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_max_no_idx_q15.c
+++ b/Source/StatisticsFunctions/arm_max_no_idx_q15.c
@@ -109,7 +109,7 @@ ARM_DSP_ATTRIBUTE void arm_max_no_idx_q15(
   q15_t maxVal1, out;       /* Temporary variables to store the output value. */     
   uint32_t blkCnt;              /* loop counter */                                 
                                                                                    
-  /* Load first input value that act as reference value for comparision */         
+  /* Load first input value that act as reference value for comparison */         
   out = *pSrc++;                                                                   
                                                                                    
   blkCnt = (blockSize - 1U);                                                       

--- a/Source/StatisticsFunctions/arm_max_no_idx_q31.c
+++ b/Source/StatisticsFunctions/arm_max_no_idx_q31.c
@@ -109,7 +109,7 @@ ARM_DSP_ATTRIBUTE void arm_max_no_idx_q31(
   q31_t maxVal1, out;       /* Temporary variables to store the output value. */    
   uint32_t blkCnt;              /* loop counter */                                  
                                                                                     
-  /* Load first input value that act as reference value for comparision */          
+  /* Load first input value that act as reference value for comparison */          
   out = *pSrc++;                                                                    
                                                                                     
   blkCnt = (blockSize - 1U);                                                        

--- a/Source/StatisticsFunctions/arm_max_no_idx_q7.c
+++ b/Source/StatisticsFunctions/arm_max_no_idx_q7.c
@@ -110,7 +110,7 @@ ARM_DSP_ATTRIBUTE void arm_max_no_idx_q7(
   q7_t maxVal1, out;       /* Temporary variables to store the output value. */     
   uint32_t blkCnt;              /* loop counter */                                  
                                                                                     
-  /* Load first input value that act as reference value for comparision */          
+  /* Load first input value that act as reference value for comparison */          
   out = *pSrc++;                                                                    
                                                                                     
   blkCnt = (blockSize - 1U);                                                        

--- a/Source/StatisticsFunctions/arm_max_q15.c
+++ b/Source/StatisticsFunctions/arm_max_q15.c
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE void arm_max_q15(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/StatisticsFunctions/arm_max_q31.c
+++ b/Source/StatisticsFunctions/arm_max_q31.c
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE void arm_max_q31(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/StatisticsFunctions/arm_max_q7.c
+++ b/Source/StatisticsFunctions/arm_max_q7.c
@@ -167,7 +167,7 @@ ARM_DSP_ATTRIBUTE void arm_max_q7(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/StatisticsFunctions/arm_min_f16.c
+++ b/Source/StatisticsFunctions/arm_min_f16.c
@@ -148,7 +148,7 @@ ARM_DSP_ATTRIBUTE void arm_min_f16(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/StatisticsFunctions/arm_min_f32.c
+++ b/Source/StatisticsFunctions/arm_min_f32.c
@@ -273,7 +273,7 @@ ARM_DSP_ATTRIBUTE void arm_min_f32(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/StatisticsFunctions/arm_min_f64.c
+++ b/Source/StatisticsFunctions/arm_min_f64.c
@@ -56,7 +56,7 @@ ARM_DSP_ATTRIBUTE void arm_min_f64(
   /* Initialise index value to zero. */
   outIndex = 0U;
 
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
   /* Initialize blkCnt with number of samples */

--- a/Source/StatisticsFunctions/arm_min_no_idx_q15.c
+++ b/Source/StatisticsFunctions/arm_min_no_idx_q15.c
@@ -109,7 +109,7 @@ ARM_DSP_ATTRIBUTE void arm_min_no_idx_q15(
   q15_t minVal1, out;       /* Temporary variables to store the output value. */    
   uint32_t blkCnt;              /* loop counter */                                  
                                                                                     
-  /* Load first input value that act as reference value for comparision */          
+  /* Load first input value that act as reference value for comparison */          
   out = *pSrc++;                                                                    
                                                                                     
   blkCnt = (blockSize - 1U);                                                        

--- a/Source/StatisticsFunctions/arm_min_no_idx_q31.c
+++ b/Source/StatisticsFunctions/arm_min_no_idx_q31.c
@@ -108,7 +108,7 @@ ARM_DSP_ATTRIBUTE void arm_min_no_idx_q31(
   q31_t minVal1, out;       /* Temporary variables to store the output value. */    
   uint32_t blkCnt;              /* loop counter */                                  
                                                                                     
-  /* Load first input value that act as reference value for comparision */          
+  /* Load first input value that act as reference value for comparison */          
   out = *pSrc++;                                                                    
                                                                                     
   blkCnt = (blockSize - 1U);                                                        

--- a/Source/StatisticsFunctions/arm_min_no_idx_q7.c
+++ b/Source/StatisticsFunctions/arm_min_no_idx_q7.c
@@ -108,7 +108,7 @@ ARM_DSP_ATTRIBUTE void arm_min_no_idx_q7(
   q7_t minVal1, out;       /* Temporary variables to store the output value. */    
   uint32_t blkCnt;              /* loop counter */                                  
                                                                                     
-  /* Load first input value that act as reference value for comparision */          
+  /* Load first input value that act as reference value for comparison */          
   out = *pSrc++;                                                                    
                                                                                     
   blkCnt = (blockSize - 1U);                                                        

--- a/Source/StatisticsFunctions/arm_min_q15.c
+++ b/Source/StatisticsFunctions/arm_min_q15.c
@@ -114,7 +114,7 @@ ARM_DSP_ATTRIBUTE void arm_min_q15(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/StatisticsFunctions/arm_min_q31.c
+++ b/Source/StatisticsFunctions/arm_min_q31.c
@@ -114,7 +114,7 @@ ARM_DSP_ATTRIBUTE void arm_min_q31(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/StatisticsFunctions/arm_min_q7.c
+++ b/Source/StatisticsFunctions/arm_min_q7.c
@@ -195,7 +195,7 @@ ARM_DSP_ATTRIBUTE void arm_min_q7(
 
   /* Initialise index value to zero. */
   outIndex = 0U;
-  /* Load first input value that act as reference value for comparision */
+  /* Load first input value that act as reference value for comparison */
   out = *pSrc++;
 
 #if defined (ARM_MATH_LOOPUNROLL)

--- a/Source/SupportFunctions/arm_q15_to_q7.c
+++ b/Source/SupportFunctions/arm_q15_to_q7.c
@@ -144,7 +144,7 @@ ARM_DSP_ATTRIBUTE void arm_q15_to_q7(
     /* oring two values(contains two 8 bit values) to get four packed 8 bit values */
     out1 = out1 | out2;
 
-    /* store 4 samples at a time to destiantion buffer */
+    /* store 4 samples at a time to destination buffer */
     write_q7x4_ia (&pDst, out1);
 
 #else

--- a/Source/SupportFunctions/arm_q7_to_q15.c
+++ b/Source/SupportFunctions/arm_q7_to_q15.c
@@ -125,7 +125,7 @@ ARM_DSP_ATTRIBUTE void arm_q7_to_q15(
     /* rotatate in by 8 and extend two q7_t values to q15_t values */
     in1 = __SXTB16(__ROR(in, 8));
 
-    /* extend remainig two q7_t values to q15_t values */
+    /* extend remaining two q7_t values to q15_t values */
     in2 = __SXTB16(in);
 
     in1 = in1 << 8U;

--- a/Source/SupportFunctions/arm_weighted_average_f16.c
+++ b/Source/SupportFunctions/arm_weighted_average_f16.c
@@ -55,7 +55,7 @@
  *
  *
  * @param[in]    *in           Array of input values.
- * @param[in]    *weigths      Weights
+ * @param[in]    *weights      Weights
  * @param[in]    blockSize     Number of samples in the input array.
  * 
  * @return       Weighted average
@@ -66,7 +66,7 @@
 
 #include "arm_helium_utils.h"
 
-ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in,const float16_t *weigths, uint32_t blockSize)
+ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in,const float16_t *weights, uint32_t blockSize)
 {
     _Float16       accum1, accum2;
     float16x8_t    accum1V, accum2V;
@@ -76,7 +76,7 @@ ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in,const f
 
 
     pIn = in;
-    pW = weigths;
+    pW = weights;
 
 
     accum1V = vdupq_n_f16(0.0f16);
@@ -113,7 +113,7 @@ ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in,const f
 
 #else
 
-ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in, const float16_t *weigths, uint32_t blockSize)
+ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in, const float16_t *weights, uint32_t blockSize)
 {
 
     _Float16 accum1, accum2;
@@ -122,7 +122,7 @@ ARM_DSP_ATTRIBUTE float16_t arm_weighted_average_f16(const float16_t *in, const 
 
 
     pIn = in;
-    pW = weigths;
+    pW = weights;
 
     accum1=0.0f16;
     accum2=0.0f16;

--- a/Source/SupportFunctions/arm_weighted_average_f32.c
+++ b/Source/SupportFunctions/arm_weighted_average_f32.c
@@ -42,7 +42,7 @@
  *
  *
  * @param[in]    *in           Array of input values.
- * @param[in]    *weigths      Weights
+ * @param[in]    *weights      Weights
  * @param[in]    blockSize     Number of samples in the input array.
  * @return       Weighted average
  *
@@ -52,7 +52,7 @@
 
 #include "arm_helium_utils.h"
 
-ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const float32_t *weigths, uint32_t blockSize)
+ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const float32_t *weights, uint32_t blockSize)
 {
     float32_t       accum1, accum2;
     f32x4_t         accum1V, accum2V;
@@ -62,7 +62,7 @@ ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const f
 
 
     pIn = in;
-    pW = weigths;
+    pW = weights;
 
 
     accum1V = vdupq_n_f32(0.0);
@@ -101,7 +101,7 @@ ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const f
 #if defined(ARM_MATH_NEON)
 
 #include "NEMath.h"
-ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const float32_t *weigths, uint32_t blockSize)
+ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const float32_t *weights, uint32_t blockSize)
 {
 
     float32_t accum1, accum2;
@@ -115,7 +115,7 @@ ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const f
 
 
     pIn = in;
-    pW = weigths;
+    pW = weights;
 
     accum1=0.0f;
     accum2=0.0f;
@@ -155,7 +155,7 @@ ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in,const f
     return(accum1 / accum2);
 }
 #else
-ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in, const float32_t *weigths, uint32_t blockSize)
+ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in, const float32_t *weights, uint32_t blockSize)
 {
 
     float32_t accum1, accum2;
@@ -164,7 +164,7 @@ ARM_DSP_ATTRIBUTE float32_t arm_weighted_average_f32(const float32_t *in, const 
 
 
     pIn = in;
-    pW = weigths;
+    pW = weights;
 
     accum1=0.0f;
     accum2=0.0f;

--- a/Source/TransformFunctions/arm_cfft_f32.c
+++ b/Source/TransformFunctions/arm_cfft_f32.c
@@ -702,7 +702,7 @@ extern void arm_bitreversal_32(
                    needed FFTs.</b> Other FFT versions can continue to be initialized as
                    explained below.
   @par
-                   For versions not targetting Helium or Neon, pre-initialized data structures containing twiddle factors
+                   For versions not targeting Helium or Neon, pre-initialized data structures containing twiddle factors
                    and bit reversal tables are provided and defined in <code>arm_const_structs.h</code>.  Include
                    this header in your function and then pass one of the constant structures as
                    an argument to arm_cfft_f32.  For example:
@@ -770,7 +770,7 @@ extern void arm_bitreversal_32(
                    Pre-initialized data structures containing twiddle factors and bit reversal
                    tables are provided and defined in <code>arm_const_structs.h</code>.  Include
                    this header in your function and then pass one of the constant structures as
-                   an argument to arm_cfft_q31 (except if you are targetting Helium or Neon). For example:
+                   an argument to arm_cfft_q31 (except if you are targeting Helium or Neon). For example:
   @par
                    <code>arm_cfft_q31(arm_cfft_sR_q31_len64, pSrc, 1, 1)</code>
   @par

--- a/Source/TransformFunctions/arm_cfft_radix4_init_f16.c
+++ b/Source/TransformFunctions/arm_cfft_radix4_init_f16.c
@@ -38,7 +38,7 @@
 
 /**
   @brief         Initialization function for the floating-point CFFT/CIFFT.
-  @deprecated    Do not use this function. It has been superceded by \ref arm_cfft_f16 and will be removed in the future.
+  @deprecated    Do not use this function. It has been superseded by \ref arm_cfft_f16 and will be removed in the future.
   @param[in,out] S              points to an instance of the floating-point CFFT/CIFFT structure
   @param[in]     fftLen         length of the FFT
   @param[in]     ifftFlag       flag that selects transform direction

--- a/Source/TransformFunctions/arm_cfft_radix4_init_f32.c
+++ b/Source/TransformFunctions/arm_cfft_radix4_init_f32.c
@@ -37,7 +37,7 @@
 
 /**
   @brief         Initialization function for the floating-point CFFT/CIFFT.
-  @deprecated    Do not use this function. It has been superceded by \ref arm_cfft_f32 and will be removed in the future.
+  @deprecated    Do not use this function. It has been superseded by \ref arm_cfft_f32 and will be removed in the future.
   @param[in,out] S              points to an instance of the floating-point CFFT/CIFFT structure
   @param[in]     fftLen         length of the FFT
   @param[in]     ifftFlag       flag that selects transform direction

--- a/Source/TransformFunctions/arm_rfft_fast_f16.c
+++ b/Source/TransformFunctions/arm_rfft_fast_f16.c
@@ -315,7 +315,7 @@ static void merge_rfft_f16(
 #elif defined(ARM_MATH_NEON_FLOAT16) && !defined(ARM_MATH_AUTOVECTORIZE)
 /*
 
-No stage merge functins defined here for Neon.
+No stage merge functions defined here for Neon.
 
 */
 #else

--- a/Source/TransformFunctions/arm_rfft_fast_f32.c
+++ b/Source/TransformFunctions/arm_rfft_fast_f32.c
@@ -309,7 +309,7 @@ static void merge_rfft_f32(
 #elif defined(ARM_MATH_NEON) && !defined(ARM_MATH_AUTOVECTORIZE)
 /*
 
-No stage merge functins defined here for Neon.
+No stage merge functions defined here for Neon.
 
 */
 #else

--- a/Testing/FrameworkInclude/ArrayMemory.h
+++ b/Testing/FrameworkInclude/ArrayMemory.h
@@ -52,14 +52,14 @@ class ArrayMemory:public Client::Memory
      // Size of C array buffer
      size_t m_bufferLength;
      // Alignment required for all buffers
-     // (in future may be a setting per bufer)
+     // (in future may be a setting per buffer)
      int alignSize;
      // True if some padding must be added after buffers
      bool tail=true;
      // Current pointer to the memory 
      // It is where a new buffer will be allocated
      char *m_currentPtr;
-     // Error occured
+     // Error occurred
      bool memError=false;
 
      size_t getTailSize();

--- a/Testing/FrameworkInclude/Semihosting.h
+++ b/Testing/FrameworkInclude/Semihosting.h
@@ -105,7 +105,7 @@ Semihosting driver. Used to read a text file describing how to drive the test.
       void recomputeTestDir();
       // Get the path to a pattern from a pattern ID
       std::string getPatternPath(Testing::PatternID_t id);
-      // Get a path to an output file from an ouput category
+      // Get a path to an output file from an output category
       // (test ID will be used so same output ID
       // is giving different names for different tests)
       std::string getOutputPath(Testing::outputID_t id);
@@ -131,7 +131,7 @@ Semihosting driver. Used to read a text file describing how to drive the test.
       // (where to find pattenrs)
       std::string testDir;
       // Array of folder used to build the 
-      // testDir parth
+      // testDir path
       std::vector<std::string> *path;
       // Root directory for patterns
       std::string patternRootPath;

--- a/Testing/FrameworkInclude/Test.h
+++ b/Testing/FrameworkInclude/Test.h
@@ -41,7 +41,7 @@
 #define MAX_NB_SAMPLES 0
 
 // Pattern files are containing hexadecimal values.
-// So we need to be able to convert some int into float without convertion
+// So we need to be able to convert some int into float without conversion
 //#define TOINT16(v) *((uint16_t*)&v)
 //#define TOINT32(v) *((uint32_t*)&v)
 //#define TOINT64(v) *((uint64_t*)&v)
@@ -49,7 +49,7 @@
 #define TOINT16(d,v) memcpy(&d,&v,2)
 #define TOINT32(d,v) memcpy(&d,&v,4)
 #define TOINT64(d,v) memcpy(&d,&v,8)
-// Or convert some  float into a uint32 or uint64 without convertion
+// Or convert some  float into a uint32 or uint64 without conversion
 //#define TOTYP(TYP,v) *((TYP*)&v)
 // So it is a cast and not a data conversion.
 // (uint32_t)1.0 would give 1. We want the hexadecimal representation of the float.
@@ -159,14 +159,14 @@ API of Memory managers used in the test framework
 
     // Memory allocation errors must be tracked during a test.
     // The runner should force the test status to FAILED
-    // when a memory error occured.
+    // when a memory error occurred.
     virtual bool HasMemError()=0;
 
     // When memory manager is supporting tail
     // then we can check that the tail of the buffer has not been 
     // corrupted.
     // The tail being the additional words after the end of the buffer allocated
-    // by the memory manager so that there is some seperation between
+    // by the memory manager so that there is some separation between
     // successive buffers.
     // When memory manager is not supporting tail, this function should
     // always succeed.
@@ -323,7 +323,7 @@ API of Memory managers used in the test framework
           It is not using the Memory manager since tests don't have access
           to the array of parameters.
 
-          They receive parameters as a vector argument for the setUp fucntion.
+          They receive parameters as a vector argument for the setUp function.
       */
       virtual Testing::param_t* ImportParams(Testing::PatternID_t,Testing::nbParameterEntries_t &,Testing::ParameterKind &)=0;
 
@@ -395,7 +395,7 @@ API of Memory managers used in the test framework
 // It knows how to import patterns into memory or dump
 // memory into outputs (output which may be different from a file)
 // The running mode is controlling if dumping is disabled or not.
-// But cna also be used by the runner to know if test results must be ignored or not.
+// But can also be used by the runner to know if test results must be ignored or not.
 // Pattern manager is used by the tests
 // In current version load and dump functions are visible to any body.
 // In theory they should only be visible to Patterns
@@ -408,7 +408,7 @@ public:
         maxSamples is coming from the test.
 
         A test does not know what is the length of a pattern since the test
-        has no visiblity on how the pattern is imported (file, serial port, include files
+        has no visibility on how the pattern is imported (file, serial port, include files
         etc ...).
 
         So the test is specifying the max sampls it needs.
@@ -435,7 +435,7 @@ public:
     /** Create a local pattern.
 
         Generally it is used as output of a test and has no
-        correspondance to a pattern in the suite.
+        correspondence to a pattern in the suite.
 
     */
     float64_t *local_f64(Testing::nbSamples_t);
@@ -489,7 +489,7 @@ public:
 
     // Memory allocation errors must be tracked during a test.
     // The runner should force the test status to FAILED
-    // when a memory error occured.
+    // when a memory error occurred.
     bool HasMemError()
     {
       return(m_mem->HasMemError());

--- a/Testing/FrameworkSource/Timing.cpp
+++ b/Testing/FrameworkSource/Timing.cpp
@@ -46,7 +46,7 @@ void initCycleMeasurement()
     int32_t   value = 1;
     
 
-    // peform reset:
+    // perform reset:
     if (DO_RESET)
     {
         value |= 2;             // reset all counters to zero.

--- a/Testing/PatternGeneration/Example.py
+++ b/Testing/PatternGeneration/Example.py
@@ -68,7 +68,7 @@ def generatePatterns():
     
     
     # Test patterns for each config are generated.
-    # Second argument may be used to vary the content fo files
+    # Second argument may be used to vary the content of files
     # depending on the type.
     #
     # For instance, in Tools there is Tools.loopnb which can be used

--- a/Testing/README.md
+++ b/Testing/README.md
@@ -150,7 +150,7 @@ The design is a consequence of all the requirements.
 
 A test description file is defined with a specific syntax to support R1 to R8.
 
-#### Hierachical structure
+#### Hierarchical structure
 
     group Root {
         class = Root
@@ -342,7 +342,7 @@ Generally, there is a calibration at beginning of the Runner to estimate the ove
 cycle measurements. This overhead is then removed when doing the measurement.
 
 #### IO
-According to R12 and R15, tests do not know how to access patterns. It is a responsiblity implemented with the IO, Pattern and PatternMgr.
+According to R12 and R15, tests do not know how to access patterns. It is a responsibility implemented with the IO, Pattern and PatternMgr.
 
 IO is about loading patterns and dumping output. It is not about IO in general.
 We provide 2 IO implementations : Semihosting and FPGA.
@@ -361,7 +361,7 @@ There are 3 modes, Test only, Dump only, Test and dump.
 
 In dump only mode, tests using pattern will fail but the tests will be considered as passed (because we are only interested in the output).
 
-But it means that no test using patterns shoudl be used in the middle of the test or some part of it may not be executed. Those tests must be kept at the end.
+But it means that no test using patterns should be used in the middle of the test or some part of it may not be executed. Those tests must be kept at the end.
 
 #### processResult
 For R14, we have a python script which will process the result of tests and format it into several possible formats like text, CSV, Mathematica dataset. 
@@ -424,7 +424,7 @@ always use -e option.
 
     python processTests.py -e
 
-You can pass a C++ class to specifiy that you want to generate tests only for a specific group or suite.
+You can pass a C++ class to specify that you want to generate tests only for a specific group or suite.
 
     python processTests.py -e BasicTests
 
@@ -512,7 +512,7 @@ The PARAMS must be compatible between all suites which are children of AGroup
 
 Output.pickle is used by default. It can be changed with -f option.
 
-To add a to sqlite3 databse:
+To add a to sqlite3 database:
 
     python addToDB.py -e AGroup
 

--- a/Testing/Source/Tests/ExampleCategoryF32.cpp
+++ b/Testing/Source/Tests/ExampleCategoryF32.cpp
@@ -13,7 +13,7 @@ CMSIS-DSP tests are using similar SNR values for different type (f32, q31, q15, 
 
 /*
 
-With thie threshold, the test will fail
+With this threshold, the test will fail
 
 #define REL_ERROR (2.0e-6) 
 

--- a/Testing/Source/Tests/QuaternionTestsF32.cpp
+++ b/Testing/Source/Tests/QuaternionTestsF32.cpp
@@ -136,7 +136,7 @@ a double precision computation.
         /*
 
         q and -q are representing the same rotation.
-        To remove the ambiguity we force the real part ot be positive.
+        To remove the ambiguity we force the real part to be positive.
         Same convention followed in Python script.
 
         */

--- a/Testing/Source/Tests/UnaryTestsF32.cpp
+++ b/Testing/Source/Tests/UnaryTestsF32.cpp
@@ -743,7 +743,7 @@ void UnaryTestsF32::test_mat_inverse_f32()
           
           /* Compute P A P^t */
 
-          // Create identiy matrix
+          // Create identity matrix
           for(int r=0; r < n; r++)
           {
             for(int c=0; c < n; c++)

--- a/Testing/Source/Tests/UnaryTestsF64.cpp
+++ b/Testing/Source/Tests/UnaryTestsF64.cpp
@@ -570,7 +570,7 @@ void UnaryTestsF64::test_mat_inverse_f64()
           
           /* Compute P A P^t */
 
-          // Create identiy matrix
+          // Create identity matrix
           for(int r=0; r < n; r++)
           {
             for(int c=0; c < n; c++)

--- a/Testing/TestScripts/CodeGen.py
+++ b/Testing/TestScripts/CodeGen.py
@@ -164,7 +164,7 @@ class CodeGen:
         with open(os.path.join(thedir,"%s_decl.h" % theClass),"w") as decl:
             # Use list of test functions to
             # declare them in the header.
-            # Since we don't want to declare the functino several times,
+            # Since we don't want to declare the function several times,
             # that's why we needed to keep track of functions in the code above:
             # to remove redundancies since the function
             # can appear several time in the root object.
@@ -223,7 +223,7 @@ class CodeGen:
            if root.kind == TestScripts.Parser.TreeElem.GROUP:
                # For a group, first iterate on the children then on the
                # parent because the parent definitino in the header is
-               # dependent on the children definition (member varaiables)
+               # dependent on the children definition (member variables)
                # So children must gbe defined before.
                for c in root:
                    self._genCode(c,dir,sourceFile,headerFile)
@@ -281,12 +281,12 @@ class CodeGen:
         Then, if node is a suite, description of the suite is generated.
          Number of parameters or 0
            It is the number of arguments used by function setUp (arity).
-           It is not the number of samples in a paramater file
+           It is not the number of samples in a parameter file
            The number of samples is always a multiple
            For instance if width and height are the parameters then number
            of parameters (arity) is 2.
            But each parameter file may contain several combination of (width,height)
-           So the lenght of those files will be a multiple of 2.
+           So the length of those files will be a multiple of 2.
 
          The number of patterns path is generated
          The patterns names are generated
@@ -315,7 +315,7 @@ class CodeGen:
 
         So, for a test (which is also a TreeElement in the structure),
         only node kind and node id are generated followed by 
-        param description and n for folder (since ther is never any folder)
+        param description and n for folder (since there is never any folder)
         
         In the test description file, there is never any way to change the pattern
         folder for a test.
@@ -436,7 +436,7 @@ class CodeGen:
             
       Args:
         v (int) : The int64 to write
-        f (file) : the opended file
+        f (file) : the opened file
       Raises:
         Nothing 
       Returns:
@@ -469,7 +469,7 @@ class CodeGen:
             
       Args:
         v (int) : The int32 to write
-        f (file) : the opended file
+        f (file) : the opened file
       Raises:
         Nothing 
       Returns:
@@ -495,7 +495,7 @@ class CodeGen:
             
       Args:
         v (int) : The int3 to write
-        f (file) : the opended file
+        f (file) : the opened file
       Raises:
         Nothing 
       Returns:
@@ -515,7 +515,7 @@ class CodeGen:
             
       Args:
         v (int) : The int to write
-        f (file) : the opended file
+        f (file) : the opened file
       Raises:
         Nothing 
       Returns:
@@ -533,7 +533,7 @@ class CodeGen:
               
         Args:
           v (str) : The string to write
-          f (file) : the opended file
+          f (file) : the opened file
         Raises:
           Nothing 
         Returns:
@@ -614,7 +614,7 @@ class CodeGen:
             pat.readline()
             # Then we read the Value 
             v = self.convertToInt(k,pat.readline())
-            # Depending on the word size, this hex must be writen to 
+            # Depending on the word size, this hex must be written to 
             # the C array as 4,2 or 1 number.
             if k == 'D':
                self._write64(v,includeFile)
@@ -679,7 +679,7 @@ class CodeGen:
             # and then a line giving the hex data
             # Then we read the Value 
             v = int(pat.readline().strip(),0)
-            # Depending on the word size, this hex must be writen to 
+            # Depending on the word size, this hex must be written to 
             # the C array as 4,2 or 1 number.
             self._write32(v,includeFile)
           # Add the padding to the pattern
@@ -850,7 +850,7 @@ class CodeGen:
       if benchMode:
         src += "Bench"
         header += "Bench"
-      # Generate .cpp and .h files neded to run the tests
+      # Generate .cpp and .h files needed to run the tests
       testDescCPath = os.path.join(src,"TestDesc.cpp")
       testDescHeaderPath = os.path.join(header,"TestDesc.h")
       with open(testDescCPath,"w") as sourceFile:

--- a/Testing/TestScripts/NewParser.py
+++ b/Testing/TestScripts/NewParser.py
@@ -146,7 +146,7 @@ def generatorDesc( str, loc, toks):
 def parseTestFields( str, loc, toks):
     if "fields" in toks:
         fields = toks["fields"]
-        # merge list of dictionnaries into a dictionnary
+        # merge list of dictionaries into a dictionary
         newFields = dict((key,d[key]) for d in fields for key in d)
         return(newFields)
 

--- a/Testing/TestScripts/Parser.py
+++ b/Testing/TestScripts/Parser.py
@@ -156,7 +156,7 @@ class TreeElem:
     def classify(self):
         """ Compute the node kind recursively
 
-        Node kind is infered from the tree structure and not present
+        Node kind is inferred from the tree structure and not present
         in the test description.
         A suite is basically a leaf of the tree and only contain tests.
         A group is containing a suite or another group.

--- a/Testing/TestScripts/doc/Format.py
+++ b/Testing/TestScripts/doc/Format.py
@@ -16,7 +16,7 @@ def joinit(iterable, delimiter):
 # First we order the categories
 # Then we order the cores in each category
 # The final ORDEREDCORES is what is used
-# to order tjhe values
+# to order the values
 # Since some cores may be missing, each atble display
 # is computing a rstricted ordered core list with only the available cores.
 CORTEXCATEGORIES=["Cortex-M","Cortex-R","Cortex-A"]

--- a/Testing/addToDB.py
+++ b/Testing/addToDB.py
@@ -227,7 +227,7 @@ def addRows(conn,elem,tableName,full,runid=0):
         if field in VALKEYFIELD:
             if field == "CATEGORY":
               # Remove type extension to get category name so that
-              # all types are maped to same category which will
+              # all types are mapped to same category which will
               # help for post processing.
               testField=re.sub(r'^(.*)[:]([^:]+)(F16|F32|F64|Q31|Q15|Q7)$',r'\1',row[field])
               val = findInTable(conn,"CATEGORY","category",testField,"categoryid")

--- a/Testing/addToRegDB.py
+++ b/Testing/addToRegDB.py
@@ -234,7 +234,7 @@ def addRows(conn,elem,tableName,full,runid=0):
         if field in VALKEYFIELD:
             if field == "CATEGORY":
               # Remove type extension to get category name so that
-              # all types are maped to same category which will
+              # all types are mapped to same category which will
               # help for post processing.
               testField=re.sub(r'^(.*)[:]([^:]+)(F16|F32|F64|Q31|Q15|Q7)$',r'\1',row[field])
               val = findInTable(conn,"CATEGORY","category",testField,"categoryid")

--- a/Testing/bench.txt
+++ b/Testing/bench.txt
@@ -215,7 +215,7 @@ group Root {
               Functions {
                  Elementwise multiplication:vec_mult_f32
                  Vector addition:vec_add_f32
-                 Vector substraction:vec_sub_f32
+                 Vector subtraction:vec_sub_f32
                  Elementwise absolute value:vec_abs_f32
                  Elementwise negation:vec_negate_f32
                  Elementwise offset:vec_offset_f32
@@ -245,7 +245,7 @@ group Root {
               Functions {
                  Elementwise multiplication:vec_mult_q31
                  Vector addition:vec_add_q31
-                 Vector substraction:vec_sub_q31
+                 Vector subtraction:vec_sub_q31
                  Elementwise absolute value:vec_abs_q31
                  Elementwise negation:vec_negate_q31
                  Elementwise offset:vec_offset_q31
@@ -275,7 +275,7 @@ group Root {
               Functions {
                  Elementwise multiplication:vec_mult_q15
                  Vector addition:vec_add_q15
-                 Vector substraction:vec_sub_q15
+                 Vector subtraction:vec_sub_q15
                  Elementwise absolute value:vec_abs_q15
                  Elementwise negation:vec_negate_q15
                  Elementwise offset:vec_offset_q15
@@ -305,7 +305,7 @@ group Root {
               Functions {
                  Elementwise multiplication:vec_mult_q7
                  Vector addition:vec_add_q7
-                 Vector substraction:vec_sub_q7
+                 Vector subtraction:vec_sub_q7
                  Elementwise absolute value:vec_abs_q7
                  Elementwise negation:vec_negate_q7
                  Elementwise offset:vec_offset_q7
@@ -1119,7 +1119,7 @@ group Root {
               ParamList {
                   VECDIM,NBVECS
                   Summary VECDIM,NBVECS
-                  Names "Vector dimension","Number of suppot vectors"
+                  Names "Vector dimension","Number of support vectors"
                   Formula "VECDIM*NBVECS"
               }
 
@@ -1376,12 +1376,12 @@ group Root {
                    Matrix Inversion:test_mat_inverse_f32
                    Matrix Transpose:test_mat_trans_f32
                    Matrix Addition:test_mat_add_f32
-                   Matrix Substraction:test_mat_sub_f32
+                   Matrix Subtraction:test_mat_sub_f32
                    Matrix Vector Multiplication:test_mat_vec_mult_f32
                    Matrix Complex Transpose:test_mat_cmplx_trans_f32
                    Cholesky decomposition:test_mat_cholesky_dpo_f32 -> PARAM_CHOLESKY_ID
                    Backward substitution:test_solve_upper_triangular_f32 -> PARAM_CHOLESKY_ID
-                   Foward substitution:test_solve_lower_triangular_f32 -> PARAM_CHOLESKY_ID
+                   Forward substitution:test_solve_lower_triangular_f32 -> PARAM_CHOLESKY_ID
                    LDLT decomposition:test_ldlt_decomposition_f32 -> PARAM_CHOLESKY_ID
                 } -> PARAM1_ID
               }
@@ -1412,7 +1412,7 @@ group Root {
                    Matrix Scaling:test_mat_scale_q31
                    Matrix Transpose:test_mat_trans_q31
                    Matrix Addition:test_mat_add_q31
-                   Matrix Substraction:test_mat_sub_q31
+                   Matrix Subtraction:test_mat_sub_q31
                    Matrix Vector Multiplication:test_mat_vec_mult_q31
                    Matrix Complex Transpose:test_mat_cmplx_trans_q31
                 } -> PARAM1_ID
@@ -1443,7 +1443,7 @@ group Root {
                    Matrix Scaling:test_mat_scale_q15
                    Matrix Transpose:test_mat_trans_q15
                    Matrix Addition:test_mat_add_q15
-                   Matrix Substraction:test_mat_sub_q15
+                   Matrix Subtraction:test_mat_sub_q15
                    Matrix Vector Multiplication:test_mat_vec_mult_q15
                    Matrix Complex Transpose:test_mat_cmplx_trans_q15
                 } -> PARAM1_ID
@@ -1527,7 +1527,7 @@ group Root {
                    Matrix Inversion:test_mat_inverse_f64
                    Cholesky decomposition:test_mat_cholesky_dpo_f64 -> PARAM_CHOLESKY_ID
                    Backward substitution:test_solve_upper_triangular_f64 -> PARAM_CHOLESKY_ID
-                   Foward substitution:test_solve_lower_triangular_f64 -> PARAM_CHOLESKY_ID
+                   Forward substitution:test_solve_lower_triangular_f64 -> PARAM_CHOLESKY_ID
                 } -> PARAM1_ID
               }
            }

--- a/Testing/bench_f16.txt
+++ b/Testing/bench_f16.txt
@@ -77,7 +77,7 @@ group Root {
               Functions {
                  Elementwise multiplication:vec_mult_f16
                  Vector addition:vec_add_f16
-                 Vector substraction:vec_sub_f16
+                 Vector subtraction:vec_sub_f16
                  Elementwise absolute value:vec_abs_f16
                  Elementwise negation:vec_negate_f16
                  Elementwise offset:vec_offset_f16
@@ -354,7 +354,7 @@ group Root {
               ParamList {
                   VECDIM,NBVECS
                   Summary VECDIM,NBVECS
-                  Names "Vector dimension","Number of suppot vectors"
+                  Names "Vector dimension","Number of support vectors"
                   Formula "VECDIM*NBVECS"
               }
 
@@ -522,12 +522,12 @@ group Root {
                    Matrix Inversion:test_mat_inverse_f16
                    Matrix Transpose:test_mat_trans_f16
                    Matrix Addition:test_mat_add_f16
-                   Matrix Substraction:test_mat_sub_f16
+                   Matrix Subtraction:test_mat_sub_f16
                    Matrix Vector Multiplication:test_mat_vec_mult_f16
                    Matrix Complex Transpose:test_mat_cmplx_trans_f16
                    Cholesky decomposition:test_mat_cholesky_dpo_f16 -> PARAM_CHOLESKY_ID
                    Backward substitution:test_solve_upper_triangular_f16 -> PARAM_CHOLESKY_ID
-                   Foward substitution:test_solve_lower_triangular_f16 -> PARAM_CHOLESKY_ID
+                   Forward substitution:test_solve_lower_triangular_f16 -> PARAM_CHOLESKY_ID
                 } -> PARAM1_ID
               }
 

--- a/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
+++ b/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/fvp_sse300_mps3_s.sct
@@ -31,7 +31,7 @@ LR_CODE S_DDR4_START {
      * set this region as Non-Secure Callable. The maximum size of this
      * executable region makes it only used the space left over by the ER_CODE
      * region so that you can rely on code+veneer size combined will not exceed
-     * the S_CODE_SIZE value. We also substract from the available space the
+     * the S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     ER_CODE_CMSE_VENEER +0 ALIGN 32 {

--- a/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld
+++ b/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld
@@ -15,7 +15,7 @@
 ; */
 
 /* Linker script to configure memory regions. */
-/* This file will be run trough the pre-processor. */
+/* This file will be run through the pre-processor. */
 
 #include "region_defs.h"
 
@@ -106,7 +106,7 @@ SECTIONS
      * this region as Non-Secure Callable. The maximum size of this executable
      * region makes it only used the space left over by the ER_CODE region
      * so that you can rely on code+veneer size combined will not exceed the
-     * S_CODE_SIZE value. We also substract from the available space the
+     * S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     .gnu.sgstubs : ALIGN(32)

--- a/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/region_defs.h
+++ b/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/region_limits.h
+++ b/Testing/cmsis_build/RTE/Device/SSE-300-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/corstone310_mps3_s.ld
+++ b/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/corstone310_mps3_s.ld
@@ -18,7 +18,7 @@
 ; */
 
 /* Linker script to configure memory regions. */
-/* This file will be run trough the pre-processor. */
+/* This file will be run through the pre-processor. */
 
 #include "region_defs.h"
 

--- a/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/corstone310_mps3_s.sct
+++ b/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/corstone310_mps3_s.sct
@@ -31,7 +31,7 @@ LR_CODE S_DDR4_START {
      * set this region as Non-Secure Callable. The maximum size of this
      * executable region makes it only used the space left over by the ER_CODE
      * region so that you can rely on code+veneer size combined will not exceed
-     * the S_CODE_SIZE value. We also substract from the available space the
+     * the S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     ER_CODE_CMSE_VENEER +0 ALIGN 32 {

--- a/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/region_defs.h
+++ b/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/region_limits.h
+++ b/Testing/cmsis_build/RTE/Device/SSE-310-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/Testing/cmsis_build/configs/ARM_VHT_Corstone_310_config.txt
+++ b/Testing/cmsis_build/configs/ARM_VHT_Corstone_310_config.txt
@@ -15,8 +15,8 @@ cpu0.semihosting-enable=1                             # (bool  , init-time) defa
 #cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
 #cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
 #cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
-#cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
-#cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+#cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extensions are absent, this is ignored : [0x0..0x10]
+#cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extensions are absent, this is the total number of MPU regions : [0x0..0x10]
 #cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
 #cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
 #cpu0.SAU=0x0                                          # (int   , init-time) default = '0x4'    : Number of SAU regions (0 => no SAU) : [0x0..0x8]

--- a/Testing/cmsis_build/configs/ARM_VHT_MPS2_M33_DSP_FP_config.txt
+++ b/Testing/cmsis_build/configs/ARM_VHT_MPS2_M33_DSP_FP_config.txt
@@ -12,8 +12,8 @@ cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) defa
 cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
 cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
 cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
-cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
-cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extensions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extensions are absent, this is the total number of MPU regions : [0x0..0x10]
 cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
 cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
 cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode

--- a/Testing/cmsis_build/configs/ARM_VHT_MPS2_M35P_DSP_FP_config.txt
+++ b/Testing/cmsis_build/configs/ARM_VHT_MPS2_M35P_DSP_FP_config.txt
@@ -12,8 +12,8 @@ cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) defa
 cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
 cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
 cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
-cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
-cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extensions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extensions are absent, this is the total number of MPU regions : [0x0..0x10]
 cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
 cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
 cpu0.BIGENDINIT=0                                     # (bool  , init-time) default = '0'      : Initialize processor to big endian mode

--- a/Testing/cmsis_build/configs/ARM_VHT_MPS2_M55_config.txt
+++ b/Testing/cmsis_build/configs/ARM_VHT_MPS2_M55_config.txt
@@ -12,8 +12,8 @@ cpu0.semihosting-heap_limit=0x0                       # (int   , init-time) defa
 cpu0.semihosting-stack_base=0x0                       # (int   , init-time) default = '0x10700000' : Virtual address of base of descending stack : [0x0..0xFFFFFFFF]
 cpu0.semihosting-stack_limit=0x0                      # (int   , init-time) default = '0x10800000' : Virtual address of stack limit : [0x0..0xFFFFFFFF]
 cpu0.semihosting-cwd=""                               # (string, init-time) default = ''       : Base directory for semihosting file access.
-cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extentions are absent, this is ignored : [0x0..0x10]
-cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extentions are absent, this is the total number of MPU regions : [0x0..0x10]
+cpu0.MPU_S=0x8                                        # (int   , init-time) default = '0x8'    : Number of regions in the Secure MPU. If Security Extensions are absent, this is ignored : [0x0..0x10]
+cpu0.MPU_NS=0x8                                       # (int   , init-time) default = '0x8'    : Number of regions in the Non-Secure MPU. If Security Extensions are absent, this is the total number of MPU regions : [0x0..0x10]
 cpu0.ITM=0                                            # (bool  , init-time) default = '1'      : Level of instrumentation trace supported. false : No ITM trace included, true: ITM trace included
 cpu0.IRQLVL=0x3                                       # (int   , init-time) default = '0x3'    : Number of bits of interrupt priority : [0x3..0x8]
 cpu0.INITSVTOR=0x00000000                             # (int   , init-time) default = '0x10000000' : Secure vector-table offset at reset : [0x0..0xFFFFFF80]

--- a/Testing/cmsis_build/linker_scripts/SSE-300-MPS3/region_defs.h
+++ b/Testing/cmsis_build/linker_scripts/SSE-300-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/Testing/cmsis_build/linker_scripts/SSE-300-MPS3/region_limits.h
+++ b/Testing/cmsis_build/linker_scripts/SSE-300-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/Testing/cmsis_build/linker_scripts/ac6_sse300_mps3_s.sct
+++ b/Testing/cmsis_build/linker_scripts/ac6_sse300_mps3_s.sct
@@ -32,7 +32,7 @@ LR_CODE S_DDR4_START {
      * set this region as Non-Secure Callable. The maximum size of this
      * executable region makes it only used the space left over by the ER_CODE
      * region so that you can rely on code+veneer size combined will not exceed
-     * the S_CODE_SIZE value. We also substract from the available space the
+     * the S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     ER_CODE_CMSE_VENEER +0 ALIGN 32 {

--- a/Testing/cmsis_build/runall.py
+++ b/Testing/cmsis_build/runall.py
@@ -99,7 +99,7 @@ def run(*args,mustPrint=False,dumpStdErr=True,withExitCodeCheck=True):
             print(result.stdout)
         return(Result(result.stdout))
     except Exception as e:
-        printError("Exception occured")
+        printError("Exception occurred")
         ERROR_OCCURED = True
         return(Result(str(e),error=True))
 

--- a/Testing/cmsis_build/test.cproject.yml
+++ b/Testing/cmsis_build/test.cproject.yml
@@ -131,7 +131,7 @@ project:
 
   # A CMSIS-DSP Layer is used to be able to build
   # and test with the current source version
-  # without requring to install a CMSIS Pack
+  # without requiring to install a CMSIS Pack
   layers:
     - layer: dsp.clayer.yml 
     

--- a/Testing/processResult.py
+++ b/Testing/processResult.py
@@ -362,7 +362,7 @@ def analyseResult(resultPath,root,results,embedded,benchmark,trace,formatter):
     calibration = 0
     if trace:
       # First cycle in the trace is the calibration data
-      # The noramlisation factor must be coherent with the C code one.
+      # The normalisation factor must be coherent with the C code one.
       calibration = int(getCyclesFromTrace(trace) / 20)
     formatter.start()
     path = []

--- a/dsppp/Include/dsppp/Helium/float.hpp
+++ b/dsppp/Include/dsppp/Helium/float.hpp
@@ -74,7 +74,7 @@ typename std::enable_if<std::is_base_of<Helium,arch>::value>::type >
   /**
    * @brief      Zero lane
    *
-   * @return     Value to wrte 0 into a lane
+   * @return     Value to write 0 into a lane
    */
   static constexpr float zero_lane() {return 0.0f;};
   
@@ -83,7 +83,7 @@ typename std::enable_if<std::is_base_of<Helium,arch>::value>::type >
   /**
    * @brief      Lane value
    *
-   * @param[in]  x    Lane vlue
+   * @param[in]  x    Lane value
    *
    * @return     Value with scalar datatype
    */

--- a/dsppp/Include/dsppp/Scalar/basic.hpp
+++ b/dsppp/Include/dsppp/Scalar/basic.hpp
@@ -135,7 +135,7 @@ inline void eval(DA &v,
 }
 
 /**
- * @brief      2D expression evaluator for scalar archiecture
+ * @brief      2D expression evaluator for scalar architecture
  *
  * @param      v          Destination value
  * @param[in]  other      The expression
@@ -189,7 +189,7 @@ inline void eval2D(DA &v,
  *
  * @param[in]  a          Left hand side
  * @param[in]  b          Right hand side
- * @param[in]  l          Vector lenght
+ * @param[in]  l          Vector length
  *
  * @tparam     DA         Left hand side datatype (may be expression)
  * @tparam     DB         Right hand side datatype (may be expression)

--- a/dsppp/Include/dsppp/algorithms.hpp
+++ b/dsppp/Include/dsppp/algorithms.hpp
@@ -12,7 +12,7 @@
 
 /**
 In this file we have kernels that are written in an
-architecture independant way (using operators of the library)
+architecture independent way (using operators of the library)
 
 */
 

--- a/dsppp/Include/dsppp/arch_detection.hpp
+++ b/dsppp/Include/dsppp/arch_detection.hpp
@@ -44,7 +44,7 @@ extern "C"
 #endif
 
 
-/* Included for instrinsics definitions */
+/* Included for intrinsics definitions */
 #if defined (_MSC_VER ) 
 #include <stdint.h>
 #define __STATIC_FORCEINLINE static __forceinline

--- a/dsppp/Include/dsppp/fixed_point.hpp
+++ b/dsppp/Include/dsppp/fixed_point.hpp
@@ -404,7 +404,7 @@ struct Q<M,F,true,int64_t> {
    * 
    * Some problem may occur since the unsigned may not be representable
    * with the less bits required for the sign representation.
-   * This convertion is not saturating.
+   * This conversion is not saturating.
    */
   constexpr explicit Q(const Q<M,F,false>&other) 
     :v{value_type(other.v)} {};
@@ -736,7 +736,7 @@ struct Q<M,F,true,int32_t> {
    * 
    * Some problem may occur since the unsigned may not be representable
    * with the less bits required for the sign representation.
-   * This convertion is not saturating.
+   * This conversion is not saturating.
    */
   constexpr explicit Q(const Q<M,F,false>&other):
   v{value_type(other.v)} {};
@@ -1078,7 +1078,7 @@ struct Q<M,F,true,int16_t> {
    * 
    * Some problem may occur since the unsigned may not be representable
    * with the less bits required for the sign representation.
-   * This convertion is not saturating.
+   * This conversion is not saturating.
    */
   constexpr explicit Q(const Q<M,F,false>&other):v{value_type(other.v)} {};
 
@@ -1433,7 +1433,7 @@ struct Q<M,F,true,int8_t> {
    * 
    * Some problem may occur since the unsigned may not be representable
    * with the less bits required for the sign representation.
-   * This convertion is not saturating.
+   * This conversion is not saturating.
    */
   constexpr explicit Q(const Q<M,F,false>&other):v{value_type(other.v)} {};
 
@@ -2229,7 +2229,7 @@ struct Accumulate<MD,MS,F,S,true> {
  * @param[in]  b     Second fixed point number
  *
  * @tparam     MD    Number of mantissa bits for destination
- * @tparam     MS    Number of mantissa bits fro source
+ * @tparam     MS    Number of mantissa bits for source
  * @tparam     F     Number of fractional bits
  * @tparam     S     Is the representation signed
  *

--- a/dsppp/Include/dsppp/forward.hpp
+++ b/dsppp/Include/dsppp/forward.hpp
@@ -71,7 +71,7 @@ Is a contiguous array in memory with scalar indexing
 It can be an _Expr
 Vector has a length
 
-Generally used whe scalar indexing is required or length
+Generally used when scalar indexing is required or length
 
 */
 template<typename T>

--- a/dsppp/Include/dsppp/fusion.hpp
+++ b/dsppp/Include/dsppp/fusion.hpp
@@ -435,8 +435,8 @@ constexpr vector_length_t static_length() {
 
 /*
 
-False only when DA and DB are static vector and with differet size
-Anyother case is ok.
+False only when DA and DB are static vector and with different size
+Any other case is ok.
 
 */
 

--- a/dsppp/Include/dsppp/num_features/complex_half.hpp
+++ b/dsppp/Include/dsppp/num_features/complex_half.hpp
@@ -44,7 +44,7 @@ struct number_traits<std::complex<float16_t>>
 };
 
 /**
- * @brief      float16 vector descrition when no vector architecture
+ * @brief      float16 vector description when no vector architecture
  */
 template<typename arch>
 struct vector_traits<std::complex<float16_t>,arch,

--- a/dsppp/Include/dsppp/num_features/complex_q7.hpp
+++ b/dsppp/Include/dsppp/num_features/complex_q7.hpp
@@ -48,7 +48,7 @@ struct number_traits<std::complex<Q<17,14>>>
 };
 
 /**
- * @brief      Vector descrition when no vector architecture
+ * @brief      Vector description when no vector architecture
  *
  * @tparam     arch  Current architecture
  */

--- a/dsppp/Include/dsppp/num_features/group.hpp
+++ b/dsppp/Include/dsppp/num_features/group.hpp
@@ -48,7 +48,7 @@ struct number_traits<std::tuple<E...>>
 Assume that all E are using the same scalar type or coherent types
 like f32 and q13 that have same number of lanes.
 
-Any other mix will not work and won't be catched at build time.
+Any other mix will not work and won't be caught at build time.
 
 */
 

--- a/dsppp/Include/dsppp/num_features/half.hpp
+++ b/dsppp/Include/dsppp/num_features/half.hpp
@@ -46,7 +46,7 @@ struct number_traits<float16_t>
 
 #if !defined(ARM_MATH_MVE_FLOAT16)
 /**
- * @brief      float16 vector descrition when no vector architecture
+ * @brief      float16 vector description when no vector architecture
  */
 template<>
 struct vector_traits<float16_t> {

--- a/dsppp/Include/dsppp/num_features/q7.hpp
+++ b/dsppp/Include/dsppp/num_features/q7.hpp
@@ -48,7 +48,7 @@ struct number_traits<Q<17,14>>
 };
 
 /**
- * @brief      Vector descrition when no vector architecture
+ * @brief      Vector description when no vector architecture
  *
  * @tparam     arch  Current architecture
  */

--- a/dsppp/Include/dsppp/number.hpp
+++ b/dsppp/Include/dsppp/number.hpp
@@ -84,7 +84,7 @@ When vector is true we have a vector datatype
 A temporary accumulator datatype and an accumulator datatype.
 For most types the temporary and accumulator are the same.
 For float, vector instruction mac is doing a mac per lane.
-So temporay is a vector and the final accumulator is a float.
+So temporary is a vector and the final accumulator is a float.
 
 */
 
@@ -200,7 +200,7 @@ vmacc_p
 /*
 
 If there is the need to tune the intrinsics depending on the
-Helium variant of the architecture, somehting like that could be used.
+Helium variant of the architecture, something like that could be used.
 In practice, selection is done at level of of algorithms more than
 instructions where it may be simple to just use a #if to use the
 right intrinsics when it is available.

--- a/dsppp/Include/dsppp/vec.hpp
+++ b/dsppp/Include/dsppp/vec.hpp
@@ -583,7 +583,7 @@ inline _Expr<OP> operator+(const VA &a,
 /*
 
 Core algorithms that cannot be expressed only with high level
-abstractions and need intrinsincs.
+abstractions and need intrinsics.
 
 */
 #include "Helium/matrix_multiply.hpp"

--- a/dsppp/Include/dsppp/vector_view.hpp
+++ b/dsppp/Include/dsppp/vector_view.hpp
@@ -40,7 +40,7 @@ struct VectorView
     /**
     * @brief  Compute the number of elements in the vector view
     * @param start Vector view start index
-    * @param stop Vector view stop index (first elemnt after the view)
+    * @param stop Vector view stop index (first element after the view)
     * @return Vector dimension
     *
     */
@@ -53,7 +53,7 @@ struct VectorView
     * @brief  Create a vector view on a buffer
     * @param v Buffer of samples (not owned by the view)
     * @param start Start index of the view
-    * @param stop Stop index of the view (first elemnt after the view)
+    * @param stop Stop index of the view (first element after the view)
     *
     */
     explicit VectorView(T *v,const vector_length_t start,const vector_length_t stop):
@@ -71,7 +71,7 @@ struct VectorView
     * @brief  Create a vector view on vector
     * @param v Vector storage (not owned by the view)
     * @param start Start index of the view
-    * @param stop Stop index of the view (first elemnt after the view)
+    * @param stop Stop index of the view (first element after the view)
     *
     */
     explicit VectorView(const Vector_Base<T> &v,const index_t start,const index_t stop):
@@ -224,7 +224,7 @@ struct VectorView
     * @param other the other vector view
     *
     * The new vector view will point to the same storage as the
-    * other vector view. No copy of element is occuring.
+    * other vector view. No copy of element is occurring.
     * To copy vector view content, the expr and copy operators
     * are needed.
     */
@@ -237,7 +237,7 @@ struct VectorView
     * @param other the other vector view
     *
     * The new vector view will point to the same storage as the
-    * other vector view. No copy of element is occuring.
+    * other vector view. No copy of element is occurring.
     *
     * The other vector view is no more valid (points to null storage)
     */
@@ -487,7 +487,7 @@ struct VectorView<T,DYNAMIC>
     /**
     * @brief  Compute the number of elements in the vector view
     * @param start Vector view start index
-    * @param stop Vector view stop index (first elemnt after the view)
+    * @param stop Vector view stop index (first element after the view)
     * @param stride Stride (only known at runtime)
     * @return Vector dimension
     *
@@ -501,7 +501,7 @@ struct VectorView<T,DYNAMIC>
     * @brief  Create a vector view on a buffer
     * @param v Buffer of samples (not owned by the view)
     * @param start Start index of the view
-    * @param stop Stop index of the view (first elemnt after the view)
+    * @param stop Stop index of the view (first element after the view)
     * @param stride Stride (only known at runtime)
     *
     */
@@ -681,7 +681,7 @@ struct VectorView<T,DYNAMIC>
     * @param other the other vector view
     *
     * The new vector view will point to the same storage as the
-    * other vector view. No copy of element is occuring.
+    * other vector view. No copy of element is occurring.
     * To copy vector view content, the expr and copy operators
     * are needed.
     */
@@ -694,7 +694,7 @@ struct VectorView<T,DYNAMIC>
     * @param other the other vector view
     *
     * The new vector view will point to the same storage as the
-    * other vector view. No copy of element is occuring.
+    * other vector view. No copy of element is occurring.
     *
     * The other vector view is no more valid (points to null storage)
     */

--- a/dsppp/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld
+++ b/dsppp/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld
@@ -15,7 +15,7 @@
 ; */
 
 /* Linker script to configure memory regions. */
-/* This file will be run trough the pre-processor. */
+/* This file will be run through the pre-processor. */
 
 #include "region_defs.h"
 
@@ -106,7 +106,7 @@ SECTIONS
      * this region as Non-Secure Callable. The maximum size of this executable
      * region makes it only used the space left over by the ER_CODE region
      * so that you can rely on code+veneer size combined will not exceed the
-     * S_CODE_SIZE value. We also substract from the available space the
+     * S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     .gnu.sgstubs : ALIGN(32)

--- a/dsppp/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld.base@1.0.0
+++ b/dsppp/RTE/Device/SSE-300-MPS3/linker_SSE300MPS3_secure.ld.base@1.0.0
@@ -15,7 +15,7 @@
 ; */
 
 /* Linker script to configure memory regions. */
-/* This file will be run trough the pre-processor. */
+/* This file will be run through the pre-processor. */
 
 #include "region_defs.h"
 
@@ -106,7 +106,7 @@ SECTIONS
      * this region as Non-Secure Callable. The maximum size of this executable
      * region makes it only used the space left over by the ER_CODE region
      * so that you can rely on code+veneer size combined will not exceed the
-     * S_CODE_SIZE value. We also substract from the available space the
+     * S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     .gnu.sgstubs : ALIGN(32)

--- a/dsppp/RTE/Device/SSE-300-MPS3/region_defs.h
+++ b/dsppp/RTE/Device/SSE-300-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/dsppp/RTE/Device/SSE-300-MPS3/region_defs.h.base@1.0.0
+++ b/dsppp/RTE/Device/SSE-300-MPS3/region_defs.h.base@1.0.0
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/dsppp/RTE/Device/SSE-300-MPS3/region_limits.h
+++ b/dsppp/RTE/Device/SSE-300-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/dsppp/RTE/Device/SSE-300-MPS3/region_limits.h.base@1.0.0
+++ b/dsppp/RTE/Device/SSE-300-MPS3/region_limits.h.base@1.0.0
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/dsppp/linker_scripts/SSE-300-MPS3/region_defs.h
+++ b/dsppp/linker_scripts/SSE-300-MPS3/region_defs.h
@@ -25,7 +25,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure regions */

--- a/dsppp/linker_scripts/SSE-300-MPS3/region_limits.h
+++ b/dsppp/linker_scripts/SSE-300-MPS3/region_limits.h
@@ -23,7 +23,7 @@
  * for C/C++ but for the linker scripts too.
  * Beware of the following limitations:
  *   - LD (GCC linker) requires white space around operators.
- *   - UL postfix for macros is not suported by the linker script
+ *   - UL postfix for macros is not supported by the linker script
  ****************************************************************/
 
 /* Secure Code */

--- a/dsppp/linker_scripts/ac6_sse300_mps3_s.sct
+++ b/dsppp/linker_scripts/ac6_sse300_mps3_s.sct
@@ -32,7 +32,7 @@ LR_CODE S_CODE_START {
      * set this region as Non-Secure Callable. The maximum size of this
      * executable region makes it only used the space left over by the ER_CODE
      * region so that you can rely on code+veneer size combined will not exceed
-     * the S_CODE_SIZE value. We also substract from the available space the
+     * the S_CODE_SIZE value. We also subtract from the available space the
      * area used to align this section on 32 bytes boundary (for SAU conf).
      */
     ER_CODE_CMSE_VENEER +0 ALIGN 32 {

--- a/dsppp/run_all.py
+++ b/dsppp/run_all.py
@@ -85,7 +85,7 @@ def run(args,mustPrint=False,dumpStdErr=True,timeout=20,printCmd=False):
             print(result.stdout)
         return(Result(result.stdout))
     except Exception as e:
-        printError("Exception occured")
+        printError("Exception occurred")
         ERROR_OCCURED = True
         return(Result(str(e),error=True))
 


### PR DESCRIPTION
Extra review please on the correction of 16 instances the typo `weigths` in the diff because this would be a code change.
* Include/dsp/support_functions.h
* Include/dsp/support_functions_f16.h
* Source/SupportFunctions/arm_weighted_average_f16.c
* Source/SupportFunctions/arm_weighted_average_f32.c

```
codespell --quiet=3 --skip="*.ipynb" --write-changes \
    --ignore-words-list=afe,asure,distancef,identation,indexs,inout,nd,pris,selfs,ser,sie,tre
```
* https://github.com/codespell-project/codespell