### PR TITLE
fix the compile issue caused by the incorrect name of round-up macro

### DIFF
--- a/Testing/Source/Benchmarks/FIRQ31.cpp
+++ b/Testing/Source/Benchmarks/FIRQ31.cpp
@@ -33,7 +33,7 @@ static __ALIGNED(8) q31_t coeffArray[64];
        samples.reload(FIRQ31::SAMPLES1_Q31_ID,mgr,this->nbSamples);
        coefs.reload(FIRQ31::COEFS1_Q31_ID,mgr,this->nbTaps);
 
-       state.create(2*ROUND_UP(this->nbSamples,4) + this->nbSamples + this->nbTaps - 1,FIRQ31::STATE_Q31_ID,mgr);
+       state.create(2*ARM_ROUND_UP(this->nbSamples,4) + this->nbSamples + this->nbTaps - 1,FIRQ31::STATE_Q31_ID,mgr);
        output.create(this->nbSamples,FIRQ31::OUT_SAMPLES_Q31_ID,mgr);
 
        switch(id)


### PR DESCRIPTION
The new naming is found not updated here which caused a compile eror.