### PR TITLE
fix the issues of Controller benchmark testing

### DIFF
--- a/Testing/Include/Benchmarks/ControllerF32.h
+++ b/Testing/Include/Benchmarks/ControllerF32.h
@@ -20,6 +20,7 @@ class ControllerF32:public Client::Suite
             arm_pid_instance_f32  instPid;
             float32_t *pSrc;
             float32_t *pDst;
-            
+            float32_t *pOuta;
+            float32_t *pOutb;
             
     };

--- a/Testing/Include/Benchmarks/ControllerQ31.h
+++ b/Testing/Include/Benchmarks/ControllerQ31.h
@@ -20,6 +20,7 @@ class ControllerQ31:public Client::Suite
             arm_pid_instance_q31  instPid;
             q31_t *pSrc;
             q31_t *pDst;
-            
+            q31_t *pOuta;
+            q31_t *pOutb;
             
     };

--- a/Testing/Source/Benchmarks/ControllerF32.cpp
+++ b/Testing/Source/Benchmarks/ControllerF32.cpp
@@ -12,43 +12,55 @@
 
     void ControllerF32::test_clarke_f32() 
     {
-       float32_t Ialpha;
-       float32_t Ibeta;
+       float32_t * Ia;
+       float32_t * Ib;
+ 
+       Ia = this->pSrc;
+       Ib = this->pSrc + (this->nbSamples << 2);
        for(int i=0; i < this->nbSamples; i++)
        {
-         arm_clarke_f32(0.1,0.2,&Ialpha,&Ibeta);
+         arm_clarke_f32(*Ia++,*(--Ib),this->pOuta,this->pOutb);
        }
     }
 
     void ControllerF32::test_inv_clarke_f32() 
     {
-       float32_t Ia;
-       float32_t Ib;
+       float32_t * Ia;
+       float32_t * Ib;
+ 
+       Ia = this->pSrc;
+       Ib = this->pSrc + (this->nbSamples << 2);
        for(int i=0; i < this->nbSamples; i++)
        {
-         arm_clarke_f32(0.1,0.2,&Ia,&Ib);
+         arm_inv_clarke_f32(*Ia++,*(--Ib),this->pOuta,this->pOutb);
        }
     }
 
     void ControllerF32::test_park_f32() 
     {
-       float32_t Id,Iq;
+       float32_t * Ia;
+       float32_t * Ib;
 
+       Ia = this->pSrc;
+       Ib = this->pSrc + (this->nbSamples << 2);
        for(int i=0; i < this->nbSamples; i++)
-       {
-          arm_park_f32(0.1,0.2,&Id,&Iq,0.1,0.2);
+       {         
+	 arm_park_f32(*Ia++,*(--Ib),this->pOuta,this->pOutb,0.4539905,0.8910065); //theta = 27(Deg) 
        }
     }
 
     void ControllerF32::test_inv_park_f32() 
     {
-        float32_t Ialpha,Ibeta;
-        
-        for(int i=0; i < this->nbSamples; i++)
-        {
-           arm_inv_park_f32(0.1,0.2,&Ialpha,&Ibeta,0.1,0.2);
-        }
-    }
+       float32_t * Ia;
+       float32_t * Ib;
+
+       Ia = this->pSrc;
+       Ib = this->pSrc + (this->nbSamples << 2);
+       for(int i=0; i < this->nbSamples; i++)
+       { 
+	 arm_inv_park_f32(*Ia++,*(--Ib),this->pOuta,this->pOutb,0.4539905,0.8910065); //theta = 27(Deg) 
+       }
+    }	
 
     void ControllerF32::test_sin_cos_f32() 
     {
@@ -62,8 +74,6 @@
     
     void ControllerF32::setUp(Testing::testID_t id,std::vector<Testing::param_t>& params,Client::PatternMgr *mgr)
     {
-
-
        std::vector<Testing::param_t>::iterator it = params.begin();
        this->nbSamples = *it;
 
@@ -73,13 +83,13 @@
        switch(id)
        {
            case TEST_PID_F32_1:
-              arm_pid_init_f32(&instPid,1);
+             arm_pid_init_f32(&instPid,1);
            break;
 
        }
 
        this->pSrc=samples.ptr();
-      this->pDst=output.ptr();
+       this->pDst=output.ptr();
        
     }
 

--- a/Testing/Source/Benchmarks/ControllerQ31.cpp
+++ b/Testing/Source/Benchmarks/ControllerQ31.cpp
@@ -12,41 +12,53 @@
 
     void ControllerQ31::test_clarke_q31() 
     {
-       q31_t Ialpha;
-       q31_t Ibeta;
+       q31_t * Ia;
+       q31_t * Ib;
+
+       Ia = this->pSrc;
+       Ib = reinterpret_cast<q31_t *> (reinterpret_cast<uintptr_t>(this->pSrc) + (this->nbSamples << 2));
        for(int i=0; i < this->nbSamples; i++)
        {
-         arm_clarke_q31(0xccccccd,0x1999999a,&Ialpha,&Ibeta);
+         arm_clarke_q31(*Ia++,*(--Ib),this->pOuta,this->pOutb);
        }
     }
 
     void ControllerQ31::test_inv_clarke_q31() 
     {
-       q31_t Ia;
-       q31_t Ib;
+       q31_t * Ia;
+       q31_t * Ib;
+
+       Ia = this->pSrc;
+       Ib = reinterpret_cast<q31_t *> (reinterpret_cast<uintptr_t>(this->pSrc) + (this->nbSamples << 2));
        for(int i=0; i < this->nbSamples; i++)
        {
-         arm_clarke_q31(0xccccccd,0x1999999a,&Ia,&Ib);
+         arm_inv_clarke_q31(*Ia++,*(--Ib),this->pOuta,this->pOutb);
        }
     }
 
     void ControllerQ31::test_park_q31() 
     {
-       q31_t Id,Iq;
+       q31_t * Ia;
+       q31_t * Ib;
 
+       Ia = this->pSrc;
+       Ib = reinterpret_cast<q31_t *> (reinterpret_cast<uintptr_t>(this->pSrc) + (this->nbSamples << 2));
        for(int i=0; i < this->nbSamples; i++)
        {
-          arm_park_q31(0xccccccd,0x1999999a,&Id,&Iq,0xccccccd,0x1999999a);
+         arm_park_q31(*Ia++,*(--Ib),this->pOuta,this->pOutb,0x3a1c5c56,0x720c8074); //theta = 27(Deg)
        }
     }
 
     void ControllerQ31::test_inv_park_q31() 
     {
-        q31_t Ialpha,Ibeta;
+        q31_t * Ia;
+        q31_t * Ib;
 
+        Ia = this->pSrc;
+        Ib = reinterpret_cast<q31_t *> (reinterpret_cast<uintptr_t>(this->pSrc) + (this->nbSamples << 2));
         for(int i=0; i < this->nbSamples; i++)
         {
-           arm_inv_park_q31(0xccccccd,0x1999999a,&Ialpha,&Ibeta,0xccccccd,0x1999999a);
+          arm_inv_park_q31(*Ia++,*(--Ib),this->pOuta,this->pOutb,0x3a1c5c56,0x720c8074);
         }
     }
 


### PR DESCRIPTION
Fix some issues to enable the testing for Controller benchmarking.
1. typo such as "arm_clarke_f32" which should be "arm_inv_clarke_f32"
2. the local variables not used/referenced will be removed by compiler optimizer which caused the Controller functions not being called in fact, and generate abnormal test result consequently.
3. some incorrect constants used. e.g. value of sin or cos should be in the range of [-1, 1]  