### PR TITLE
fix a small bug of the copying history samples in taps_5-8 processing of FIRF32

### DIFF
--- a/Source/FilteringFunctions/arm_fir_f32.c
+++ b/Source/FilteringFunctions/arm_fir_f32.c
@@ -670,6 +670,7 @@ uint32_t blockSize)
     pTempSrc = &pRefStatePtr[blockSize];
     pTempDest = pRefStatePtr;
 
+    numTaps--;
     blkCnt = numTaps >> 2;
     while (blkCnt > 0)
     {

--- a/Source/FilteringFunctions/arm_fir_f32.c
+++ b/Source/FilteringFunctions/arm_fir_f32.c
@@ -348,7 +348,7 @@ __STATIC_INLINE void arm_fir_f32_5_8_mve(const arm_fir_instance_f32 * S,
     pTempSrc = &pState[blockSize];
     pTempDest = pState;
     blkCnt = numTaps;
-    while (blkCnt > 0)
+    while (blkCnt > 1)
     {
         *pTempDest++ = *pTempSrc++;
         blkCnt--;


### PR DESCRIPTION
The number of history samples being copied in arm_fir_f32_5_8_mve should be numTaps-1 (see the file head comment and arm_fir_f32_1_4_mve as reference). So, the "blkCnt = numTaps" should be changed to "blkCnt = numTaps -1". However, to save cycles, I'd rather to change the next line from "blkCnt > 0" to "blkCnt > 1". This has passed the tests and the cycles reduced indeed.
In fact, the vectorization can be used here to achieve more performance uplift but there will be a little code size increase. So I'd just request this small change this time.