### PR TITLE
FilteringFunctions: Avoid uninitialized value warnings from GCC 14.3

### DIFF
--- a/Source/FilteringFunctions/arm_fir_decimate_f32.c
+++ b/Source/FilteringFunctions/arm_fir_decimate_f32.c
@@ -393,7 +393,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_decimate_f32(
   float32_t *px0, *px1, *px2, *px3;
   float32_t x1, x2, x3;
 
-  float32x4_t accv,acc0v,acc1v,acc2v,acc3v;
+  float32x4_t accv = { 0 },acc0v,acc1v,acc2v,acc3v;
   float32x4_t x0v, x1v, x2v, x3v;
   float32x4_t c0v;
   float32x2_t temp;

--- a/Source/FilteringFunctions/arm_fir_interpolate_f32.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_f32.c
@@ -489,7 +489,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_interpolate_f32(
 
   float32x4_t sum0v;
   float32x4_t accV0,accV1;
-  float32x4_t x0v,x1v,x2v,xa,xb;
+  float32x4_t x0v,x1v = { 0 },x2v,xa,xb;
   float32x2_t tempV;
 
   /* S->pState buffer contains previous frame (phaseLen - 1) samples */


### PR DESCRIPTION
GCC version 14.3 does more extensive checking for potentially uninitialized values and warns about a couple of arrays. Initialize them to zero to make the compiler happy.