### PR TITLE
Ne10: Fix uninitialized variable in FFT functions

### DIFF
--- a/Ne10/NE10_fft_float32.neonintrinsic.c
+++ b/Ne10/NE10_fft_float32.neonintrinsic.c
@@ -1214,7 +1214,7 @@ void arm_ne10_mixed_radix_fft_forward_float32_neon (
     ne10_int32_t fstride = S->factors[1];
     ne10_int32_t mstride = S->factors[3];
     ne10_int32_t first_radix = S->factors[2];
-    ne10_int32_t step, f_count;
+    ne10_int32_t step = 0, f_count;
     const ne10_fft_cpx_float32_t *src = input;
     ne10_fft_cpx_float32_t *in;
     ne10_fft_cpx_float32_t *dst = out;
@@ -1313,7 +1313,7 @@ void arm_ne10_mixed_radix_fft_backward_float32_neon (
     ne10_int32_t mstride = S->factors[3];
     ne10_int32_t first_radix = S->factors[2];
     ne10_int32_t nfft = fstride * first_radix;
-    ne10_int32_t step, f_count;
+    ne10_int32_t step = 0, f_count;
     const ne10_fft_cpx_float32_t *src = input;
     ne10_fft_cpx_float32_t *in;
     ne10_fft_cpx_float32_t *dst = out;

--- a/Ne10/NE10_fft_int16.neonintrinsic.c
+++ b/Ne10/NE10_fft_int16.neonintrinsic.c
@@ -1026,7 +1026,7 @@ static void arm_ne10_mixed_radix_fft_forward_int16_##scaled##_neon (ne10_fft_cpx
     ne10_fft_cpx_int16_t *Fout1; \
     ne10_fft_cpx_int16_t   *Fout_ls = Fout; \
     ne10_fft_cpx_int16_t   *Ftmp; \
-    const ne10_fft_cpx_int16_t   *tw; \
+    const ne10_fft_cpx_int16_t   *tw = twiddles; \
     const ne10_fft_cpx_int16_t *tw1; \
  \
     /* init fstride, mstride, N */ \
@@ -1111,7 +1111,7 @@ static void arm_ne10_mixed_radix_fft_backward_int16_##scaled##_neon (ne10_fft_cp
     ne10_fft_cpx_int16_t *Fout1; \
     ne10_fft_cpx_int16_t   *Fout_ls = Fout; \
     ne10_fft_cpx_int16_t   *Ftmp; \
-    const ne10_fft_cpx_int16_t   *tw;\
+    const ne10_fft_cpx_int16_t   *tw = twiddles;\
     const ne10_fft_cpx_int16_t *tw1; \
  \
     /* init fstride, mstride, N */ \

--- a/Ne10/NE10_fft_int32.neonintrinsic.c
+++ b/Ne10/NE10_fft_int32.neonintrinsic.c
@@ -1267,7 +1267,7 @@ static void arm_ne10_mixed_radix_fft_forward_int32_##scaled##_neon (ne10_fft_cpx
     ne10_fft_cpx_int32_t *Fout1; \
     ne10_fft_cpx_int32_t   *Fout_ls = Fout; \
     ne10_fft_cpx_int32_t   *Ftmp; \
-    const ne10_fft_cpx_int32_t   *tw;\
+    const ne10_fft_cpx_int32_t   *tw = twiddles;\
     const ne10_fft_cpx_int32_t *tw1; \
  \
     /* init fstride, mstride, N */ \
@@ -1353,7 +1353,7 @@ static void arm_ne10_mixed_radix_fft_backward_int32_##scaled##_neon (ne10_fft_cp
     ne10_fft_cpx_int32_t   *Fout1; \
     ne10_fft_cpx_int32_t   *Fout_ls = Fout; \
     ne10_fft_cpx_int32_t   *Ftmp; \
-    const ne10_fft_cpx_int32_t   *tw; \
+    const ne10_fft_cpx_int32_t   *tw = twiddles; \
     const  ne10_fft_cpx_int32_t *tw1; \
  \
     /* init fstride, mstride, N */ \

--- a/Source/MatrixFunctions/arm_mat_mult_f64.c
+++ b/Source/MatrixFunctions/arm_mat_mult_f64.c
@@ -170,6 +170,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_mult_f64(
         acc5 = vdupq_n_f64(0.0);
         acc6 = vdupq_n_f64(0.0);
         acc7 = vdupq_n_f64(0.0);
+        temp = vdupq_n_f64(0.0);
 
         /* Compute 2 MACs simultaneously. */
         colCnt = numColsA >> 1U;
@@ -307,6 +308,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_mult_f64(
         pIn1 = pInA;
 
         acc0 = vdupq_n_f64(0.0);
+        temp = vdupq_n_f64(0.0);
 
         /* Compute 4 MACs simultaneously. */
         colCnt = numColsA >> 1U;


### PR DESCRIPTION
Initialize the 'step' variable to 0 in both forward and backward FFT functions to prevent compiler warnings about potentially uninitialized variables.

- arm_ne10_mixed_radix_fft_forward_float32_neon
- arm_ne10_mixed_radix_fft_backward_float32_neon

the warnings
```
modules/cmsis-dsp/CMakeFiles/..__modules__lib__cmsis-dsp__zephyr.dir/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c.obj -c                                                                   
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c                                                                                                                                              
In function 'ne10_radix4x4_with_twiddles_neon',                                                                                                                                                                      
    inlined from 'arm_ne10_mixed_radix_fft_forward_float32_neon' at /__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:1264:13:                                                                 
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:679:18: error: 'step' may be used uninitialized [-Werror=maybe-uninitialized]                                                                
  679 |     ne10_int32_t src_step = src_stride << 1; // ne10_fft_cpx_float32_t -> float32_t offsets                                                                                                                  
      |                  ^~~~~~~~                                                                                                                                                                                    
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c: In function 'arm_ne10_mixed_radix_fft_forward_float32_neon':                                                                                
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:1217:18: note: 'step' was declared here                                                                                                      
 1217 |     ne10_int32_t step, f_count;                                                                                                                                                                              
      |                  ^~~~                                                                                                                                                                                        
In function 'ne10_radix4x4_inverse_with_twiddles_neon',                                                                                                                                                              
    inlined from 'arm_ne10_mixed_radix_fft_backward_float32_neon' at /__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:1360:13:                                                                
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:1006:18: error: 'step' may be used uninitialized [-Werror=maybe-uninitialized]                                                               
 1006 |     ne10_int32_t src_step = src_stride << 1;                                                                                                                                                                 
      |                  ^~~~~~~~                                                                                                                                                                                    
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c: In function 'arm_ne10_mixed_radix_fft_backward_float32_neon':                                                                               
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_float32.neonintrinsic.c:1316:18: note: 'step' was declared here                                                                                                      
 1316 |     ne10_int32_t step, f_count;                                                                                                                                                                              
      |                  ^~~~                                                                                                                                                                                        
cc1: all warnings being treated as errors    
```

and another one
```
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c: In function 'arm_ne10_fft_c2c_1d_int32_neon':
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1318:12: error: 'tw' may be used uninitialized [-Werror=maybe-uninitialized]
 1318 |         tw += mstride * 3; \
      |            ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1270:35: note: 'tw' was declared here
 1270 |     const ne10_fft_cpx_int32_t   *tw;\
      |                                   ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1426:1: note: in expansion of macro 'arm_ne10_mixed_radix_fft_forward_int32_neon'
 1426 | arm_ne10_mixed_radix_fft_forward_int32_neon (unscaled)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1404:12: error: 'tw' may be used uninitialized [-Werror=maybe-uninitialized]
 1404 |         tw += mstride * 3; \
      |            ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1356:35: note: 'tw' was declared here
 1356 |     const ne10_fft_cpx_int32_t   *tw; \
      |                                   ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1428:1: note: in expansion of macro 'arm_ne10_mixed_radix_fft_backward_int32_neon'
 1428 | arm_ne10_mixed_radix_fft_backward_int32_neon (unscaled)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1318:12: error: 'tw' may be used uninitialized [-Werror=maybe-uninitialized]
 1318 |         tw += mstride * 3; \
      |            ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1270:35: note: 'tw' was declared here
 1270 |     const ne10_fft_cpx_int32_t   *tw;\
      |                                   ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1427:1: note: in expansion of macro 'arm_ne10_mixed_radix_fft_forward_int32_neon'
 1427 | arm_ne10_mixed_radix_fft_forward_int32_neon (scaled)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1404:12: error: 'tw' may be used uninitialized [-Werror=maybe-uninitialized]
 1404 |         tw += mstride * 3; \
      |            ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1356:35: note: 'tw' was declared here
 1356 |     const ne10_fft_cpx_int32_t   *tw; \
      |                                   ^~
/__w/zephyr/modules/lib/cmsis-dsp/Ne10/NE10_fft_int32.neonintrinsic.c:1429:1: note: in expansion of macro 'arm_ne10_mixed_radix_fft_backward_int32_neon'
 1429 | arm_ne10_mixed_radix_fft_backward_int32_neon (scaled)
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```