### PR TITLE
Python wrapper for python 3.14.2 on Mint 22.3

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include PythonWrapper_README.md
 recursive-include Include *.h 
 recursive-include PrivateInclude *.h 
+include PythonWrapper/CMakeLists.txt
 recursive-include PythonWrapper/cmsisdsp_pkg/src *.h 
 include Source/DistanceFunctions/arm_boolean_distance_template.h
-include PythonWrapper/CMakeLists.txt
+include Source/CMakeLists.txt
+recursive-include Source *.c *.cmake

--- a/setup.py
+++ b/setup.py
@@ -196,8 +196,8 @@ class BuildCMSISDSPExtensions(build_ext):
       "-DWRAPPER=YES",
       "-DLOOPUNROLL=ON",
       "-DCMAKE_BUILD_TYPE=Release",
-      '-DCMAKE_C_FLAGS_RELEASE="-std=c11 -O3 -ffast-math -DNDEBUG -Wall -Wextra"',
-      '-DCMAKE_CXX_FLAGS_RELEASE="-std=c++11 -O3 -ffast-math -DNDEBUG -Wall -Wextra -Wno-unused-parameter"'
+      "-DCMAKE_C_FLAGS_RELEASE=-std=c11 -O3 -ffast-math -DNDEBUG -Wall -Wextra",
+      "-DCMAKE_CXX_FLAGS_RELEASE=-std=c++11 -O3 -ffast-math -DNDEBUG -Wall -Wextra -Wno-unused-parameter"
     ]
 
     if sys.platform != 'win32':


### PR DESCRIPTION
See: https://github.com/ARM-software/CMSIS-DSP/issues/308

Compiler flags in double quotes were not recognized correctly.
This fixes `pip install .` installation.

For building wheels with `python -m build`, we also need to `recursive-include Source *.c` in the `MANIFEST.in` file.