### PR TITLE
zephyr: restore per-component build configuration options

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -52,18 +52,22 @@ endif()
   endif()
 
 # Basic math functions
+if (CONFIG_CMSIS_DSP_BASICMATH)
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/BasicMathFunctions/BasicMathFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/BasicMathFunctions/BasicMathFunctionsF16.c)
   endif()
+endif()
 
   # Bayes functions
+if (CONFIG_CMSIS_DSP_BAYES)
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/BayesFunctions/BayesFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/BayesFunctions/BayesFunctionsF16.c)
   endif()
+endif()
 
 # Common tables
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/CommonTables/arm_common_tables.c 
@@ -87,77 +91,100 @@ if (CONFIG_ARMV8_1_M_MVEI OR CONFIG_ARMV8_1_M_MVEF)
 endif()
 
 # Complex math functions
+if (CONFIG_CMSIS_DSP_COMPLEXMATH)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/ComplexMathFunctions/ComplexMathFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/ComplexMathFunctions/ComplexMathFunctionsF16.c)
   endif()
+endif()
 
 # Controller functions
+if (CONFIG_CMSIS_DSP_CONTROLLER)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/ControllerFunctions/ControllerFunctions.c)
+endif()
 
 # Distance functions
+if (CONFIG_CMSIS_DSP_DISTANCE)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/DistanceFunctions/DistanceFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/DistanceFunctions/DistanceFunctionsF16.c)
   endif()
+endif()
 
 # Fast math functions
+if (CONFIG_CMSIS_DSP_FASTMATH)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/FastMathFunctions/FastMathFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/FastMathFunctions/FastMathFunctionsF16.c)
   endif()
+endif()
 
   # Filtering functions
-
+if (CONFIG_CMSIS_DSP_FILTERING)
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/FilteringFunctions/FilteringFunctions.c)
     if (CONFIG_CMSIS_DSP_FLOAT16)
         zephyr_library_sources(${CMSIS_DSP_DIR}/Source/FilteringFunctions/FilteringFunctionsF16.c)
     endif()
+endif()
 
 # Interpolation functions
+if (CONFIG_CMSIS_DSP_INTERPOLATION)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/InterpolationFunctions/InterpolationFunctions.c)
   if (CONFIG_CMSIS_DSP_FLOAT16)
-    zephyr_library_sources(${CMSIS_DSP_DIR}/Source/InterpolationFunctions/InterpolationFunctionsF16.c)  
+    zephyr_library_sources(${CMSIS_DSP_DIR}/Source/InterpolationFunctions/InterpolationFunctionsF16.c)
   endif()
+endif()
 
 # Matrix functions
+if (CONFIG_CMSIS_DSP_MATRIX)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/MatrixFunctions/MatrixFunctions.c)
     if (CONFIG_CMSIS_DSP_FLOAT16)
-        zephyr_library_sources(${CMSIS_DSP_DIR}/Source/MatrixFunctions/MatrixFunctionsF16.c)    
+        zephyr_library_sources(${CMSIS_DSP_DIR}/Source/MatrixFunctions/MatrixFunctionsF16.c)
     endif()
+endif()
 
 # Quaternion functions
+if (CONFIG_CMSIS_DSP_QUATERNIONMATH)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/QuaternionMathFunctions/QuaternionMathFunctions.c)
+endif()
 
 # Statistics functions
+if (CONFIG_CMSIS_DSP_STATISTICS)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/StatisticsFunctions/StatisticsFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/StatisticsFunctions/StatisticsFunctionsF16.c)
   endif()
+endif()
 
 # Support functions
+if (CONFIG_CMSIS_DSP_SUPPORT)
   zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SupportFunctions/SupportFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
-    zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SupportFunctions/SupportFunctionsF16.c)  
+    zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SupportFunctions/SupportFunctionsF16.c)
   endif()
+endif()
 
 # SVM Functions
-  zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SVMFunctions/SVMFunctions.c) 
+if (CONFIG_CMSIS_DSP_SVM)
+  zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SVMFunctions/SVMFunctions.c)
     if (CONFIG_CMSIS_DSP_FLOAT16)
-        zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SVMFunctions/SVMFunctionsF16.c)  
+        zephyr_library_sources(${CMSIS_DSP_DIR}/Source/SVMFunctions/SVMFunctionsF16.c)
     endif()
+endif()
 
 # Transform functions
+if (CONFIG_CMSIS_DSP_TRANSFORM)
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/TransformFunctions/TransformFunctions.c)
 
   if (CONFIG_CMSIS_DSP_FLOAT16)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Source/TransformFunctions/TransformFunctionsF16.c)
   endif()
+endif()
 
 if (CONFIG_CMSIS_DSP_NEON OR CONFIG_CMSIS_DSP_NEON_EXPERIMENTAL)
     zephyr_library_sources(${CMSIS_DSP_DIR}/Ne10/NE10_fft_float32.neonintrinsic.c)
@@ -178,6 +205,8 @@ if (CONFIG_CMSIS_DSP_NEON OR CONFIG_CMSIS_DSP_NEON_EXPERIMENTAL)
 endif()
 
 # Windows functions
+if (CONFIG_CMSIS_DSP_WINDOW)
 zephyr_library_sources(${CMSIS_DSP_DIR}/Source/WindowFunctions/WindowFunctions.c)
+endif()
 
 endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -8,6 +8,252 @@ menuconfig CMSIS_DSP
 
 if CMSIS_DSP
 
+comment "Components"
+config CMSIS_DSP_BASICMATH
+	bool "Basic Math Functions"
+	help
+	  This option enables the Basic Math Functions, which support the
+	  following operations:
+
+	  * Elementwise Clipping
+	  * Vector Absolute Value
+	  * Vector Addition
+	  * Vector Subtraction
+	  * Vector Multiplication
+	  * Vector Dot Product
+	  * Vector Absolute Value
+	  * Vector Negate
+	  * Vector Offset
+	  * Vector Scale
+	  * Vector Shift
+	  * Vector Bitwise AND
+	  * Vector Bitwise OR
+	  * Vector Bitwise Exclusive OR
+	  * Vector Bitwise NOT
+
+config CMSIS_DSP_COMPLEXMATH
+	bool "Complex Math Functions"
+	imply CMSIS_DSP_FASTMATH
+	help
+	  This option enables the Complex Math Functions, which support the
+	  following operations:
+
+	  * Complex-by-Complex Multiplication
+	  * Complex-by-Real Multiplication
+	  * Complex Dot Product
+	  * Complex Magnitude
+	  * Complex Magnitude Squared
+	  * Complex Conjugate
+
+config CMSIS_DSP_CONTROLLER
+	bool "Controller Functions"
+	help
+	  This option enables the Controller Functions, which support the
+	  following operations:
+
+	  * PID Control
+	  * Vector Clarke Transform
+	  * Vector Inverse Clarke Transform
+	  * Vector Park Transform
+	  * Vector Inverse Park Transform
+	  * Sine-Cosine
+
+	  These functions can be used to implement a generic PID controller, as
+	  well as field oriented motor control using Space Vector Modulation
+	  algorithm.
+
+config CMSIS_DSP_FASTMATH
+	bool "Fast Math Functions"
+	imply CMSIS_DSP_BASICMATH
+	help
+	  This option enables the Fast Math Functions, which support the
+	  following operations:
+
+	  * Fixed-Point Division
+	  * Sine
+	  * Cosine
+	  * Square Root
+
+config CMSIS_DSP_FILTERING
+	bool "Filtering Functions"
+	imply CMSIS_DSP_BASICMATH
+	imply CMSIS_DSP_FASTMATH
+	imply CMSIS_DSP_SUPPORT
+	help
+	  This option enables the Filtering Functions, which support the
+	  following operations:
+
+	  * Convolution
+	  * Partial Convolution
+	  * Correlation
+	  * Levinson-Durbin Algorithm
+
+	  The following filter types are supported:
+
+	  * FIR (finite impulse response) Filter
+	  * FIR Lattice Filter
+	  * FIR Sparse Filter
+	  * FIR Filter with Decimator
+	  * FIR Filter with Interpolator
+	  * IIR (infinite impulse response) Lattice Filter
+	  * Biquad Cascade IIR Filter, Direct Form I Structure
+	  * Biquad Cascade IIR Filter, Direct Form II Transposed Structure
+	  * High Precision Q31 Biquad Cascade Filter
+	  * LMS (least mean square) Filter
+	  * Normalized LMS Filter
+
+config CMSIS_DSP_INTERPOLATION
+	bool "Interpolation Functions"
+	help
+	  This option enables the Interpolation Functions, which support the
+	  following operations:
+
+	  * Bilinear Interpolation
+	  * Linear Interpolation
+	  * Cubic Spline Interpolation
+
+config CMSIS_DSP_MATRIX
+	bool "Matrix Functions"
+	help
+	  This option enables the Matrix Functions, which support the following
+	  operations:
+
+	  * Matrix Initialization
+	  * Matrix Addition
+	  * Matrix Subtraction
+	  * Matrix Multiplication
+	  * Complex Matrix Multiplication
+	  * Matrix Vector Multiplication
+	  * Matrix Inverse
+	  * Matrix Scale
+	  * Matrix Transpose
+	  * Complex Matrix Transpose
+	  * Cholesky and LDLT Decompositions
+
+config CMSIS_DSP_QUATERNIONMATH
+	bool "Quaternion Math Functions"
+	help
+	  This option enables the Quaternion Math Functions, which support the
+	  following operations:
+
+	  * Quaternion Conversions
+	  * Quaternion Conjugate
+	  * Quaternion Inverse
+	  * Quaternion Norm
+	  * Quaternion Normalization
+	  * Quaternion Product
+
+config CMSIS_DSP_STATISTICS
+	bool "Statistics Functions"
+	imply CMSIS_DSP_BASICMATH
+	imply CMSIS_DSP_FASTMATH
+	help
+	  This option enables the Statistics Functions, which support the
+	  following operations:
+
+	  * Minimum
+	  * Absolute Minimum
+	  * Maximum
+	  * Absolute Maximum
+	  * Mean
+	  * Root Mean Square (RMS)
+	  * Variance
+	  * Standard Deviation
+	  * Power
+	  * Entropy
+	  * Kullback-Leibler Divergence
+	  * LogSumExp (LSE)
+
+config CMSIS_DSP_SUPPORT
+	bool "Support Functions"
+	help
+	  This option enables the Support Functions, which support the
+	  following operations:
+
+	  * Vector 8-bit Integer Value Conversion
+	  * Vector 16-bit Integer Value Conversion
+	  * Vector 32-bit Integer Value Conversion
+	  * Vector 16-bit Floating-Point Value Conversion
+	  * Vector 32-bit Floating-Point Value Conversion
+	  * Vector Copy
+	  * Vector Fill
+	  * Vector Sorting
+	  * Weighted Sum
+	  * Barycenter
+
+config CMSIS_DSP_TRANSFORM
+	bool "Transform Functions"
+	imply CMSIS_DSP_BASICMATH
+	help
+	  This option enables the Transform Functions, which support the
+	  following transformations:
+
+	  * Real Fast Fourier Transform (RFFT)
+	  * Complex Fast Fourier Transform (CFFT)
+	  * Type IV Discrete Cosine Transform (DCT4)
+
+config CMSIS_DSP_SVM
+	bool "Support Vector Machine Functions"
+	help
+	  This option enables the Support Vector Machine Functions, which
+	  support the following algorithms:
+
+	  * Linear
+	  * Polynomial
+	  * Sigmoid
+	  * Radial Basis Function (RBF)
+
+config CMSIS_DSP_BAYES
+	bool "Bayesian Estimators"
+	imply CMSIS_DSP_STATISTICS
+	help
+	  This option enables the Bayesian Estimator Functions, which
+	  implements the naive gaussian Bayes estimator.
+
+config CMSIS_DSP_DISTANCE
+	bool "Distance Functions"
+	imply CMSIS_DSP_STATISTICS
+	help
+	  This option enables the Distance Functions, which support the
+	  following distance computation algorithms:
+
+	  * Boolean Vectors
+	    * Hamming
+	    * Jaccard
+	    * Kulsinski
+	    * Rogers-Tanimoto
+	    * Russell-Rao
+	    * Sokal-Michener
+	    * Sokal-Sneath
+	    * Yule
+	    * Dice
+
+	  * Floating-Point Vectors
+	    * Canberra
+	    * Chebyshev
+	    * Cityblock
+	    * Correlation
+	    * Cosine
+	    * Euclidean
+	    * Jensen-Shannon
+	    * Minkowski
+	    * Bray-Curtis
+
+config CMSIS_DSP_WINDOW
+	bool "Windowing Functions"
+	help
+	  This option enabled the Window Functions, which support the
+	  following windowing functions:
+
+	  * Bartlett
+	  * Hamming
+	  * Hanning
+	  * Nuttall
+	  * Blackman Harris
+	  * HFT
+
+comment "Instruction Set"
+
 config CMSIS_DSP_NEON
 	bool "Neon Instruction Set"
 	default y


### PR DESCRIPTION
### Summary

Re-introduces the per-category `CONFIG_CMSIS_DSP_<COMPONENT>` Kconfig options
(BASICMATH, COMPLEXMATH, CONTROLLER, FASTMATH, FILTERING, INTERPOLATION, MATRIX,
QUATERNIONMATH, STATISTICS, SUPPORT, TRANSFORM, SVM, BAYES, DISTANCE, WINDOW) in
the Zephyr integration and gates the corresponding source files in
`zephyr/CMakeLists.txt` behind them.

The options default to `n` and carry the same `imply` relationships as before, so
enabling a component pulls in the components it depends on. Applications opt in to
only the components they use.

### Motivation

The current Zephyr integration compiles every component unconditionally, building
the entire library for every test, sample, and application that enables CMSIS-DSP
regardless of which functions are actually used. Across the hundreds of builds and
platforms in Zephyr's CI this is a significant and unnecessary compile-time cost.

This was raised in review of the Zephyr v1.17.0 update:
https://github.com/zephyrproject-rtos/zephyr/pull/105315#pullrequestreview-4368770561

> No, those options didn't really provide anything 'functional', they only made
> things compile "faster"... especially when there are hundreds of tests and
> samples built for hundreds of platforms. Removing these will significantly
> increase CI load for no good reason.

Measured impact (Zephyr SDK, `frdm_k64f`, building `tests/lib/cmsis_dsp/matrix`):
restoring the flags drops the CMSIS-DSP build from 31 component translation units
back to only those the test needs, roughly a 5x reduction in DSP compile CPU time
for that build.

### Verification

Full Zephyr DSP test suite (`tests/lib/cmsis_dsp`, `tests/subsys/dsp`,
`tests/benchmarks/cmsis_dsp`) passes: 0 failures, 33334/33342 test cases passing
(the only errors are a pre-existing OpenRISC SDK libc link issue unrelated to this
change). No undefined-reference regressions, confirming the `imply` chains are
intact.