### PR TITLE
fix(FilteringFunctions): guard arm_fir_sparse_* against numTaps==1 underflow

### DIFF
--- a/Source/FilteringFunctions/arm_fir_sparse_f32.c
+++ b/Source/FilteringFunctions/arm_fir_sparse_f32.c
@@ -199,6 +199,11 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_f32(
     blkCnt--;
   }
 
+  /* Remaining taps (2nd tap onward) only exist when numTaps > 1.
+   * Guard against unsigned underflow of tapCnt and the associated
+   * out-of-bounds read of pCoeffs/pTapDelay when numTaps == 1. */
+  if (numTaps > 1U)
+  {
   /* Load the coefficient value and
    * increment the coefficient buffer for the next set of state values */
   coeff = *pCoeffs++;
@@ -338,6 +343,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_f32(
     /* Decrement loop counter */
     blkCnt--;
   }
+  } /* if (numTaps > 1U) */
 
 }
 

--- a/Source/FilteringFunctions/arm_fir_sparse_q15.c
+++ b/Source/FilteringFunctions/arm_fir_sparse_q15.c
@@ -156,6 +156,11 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q15(
     blkCnt--;
   }
 
+  /* Remaining taps (2nd tap onward) only exist when numTaps > 1.
+   * Guard against unsigned underflow of tapCnt and the associated
+   * out-of-bounds read of pCoeffs/pTapDelay when numTaps == 1. */
+  if (numTaps > 1U)
+  {
   /* Load the coefficient value and
    * increment the coefficient buffer for the next set of state values */
   coeff = *pCoeffs++;
@@ -292,6 +297,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q15(
     /* Decrement loop counter */
     blkCnt--;
   }
+  } /* if (numTaps > 1U) */
 
   /* All the output values are in pScratchOut buffer.
      Convert them into 1.15 format, saturate and store in the destination buffer. */

--- a/Source/FilteringFunctions/arm_fir_sparse_q31.c
+++ b/Source/FilteringFunctions/arm_fir_sparse_q31.c
@@ -152,6 +152,11 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q31(
     blkCnt--;
   }
 
+  /* Remaining taps (2nd tap onward) only exist when numTaps > 1.
+   * Guard against unsigned underflow of tapCnt and the associated
+   * out-of-bounds read of pCoeffs/pTapDelay when numTaps == 1. */
+  if (numTaps > 1U)
+  {
   /* Load the coefficient value and
    * increment the coefficient buffer for the next set of state values */
   coeff = *pCoeffs++;
@@ -314,6 +319,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q31(
     /* Decrement loop counter */
     blkCnt--;
   }
+  } /* if (numTaps > 1U) */
 
   /* Working output pointer is updated */
   pOut = pDst;

--- a/Source/FilteringFunctions/arm_fir_sparse_q7.c
+++ b/Source/FilteringFunctions/arm_fir_sparse_q7.c
@@ -157,6 +157,11 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q7(
     blkCnt--;
   }
 
+  /* Remaining taps (2nd tap onward) only exist when numTaps > 1.
+   * Guard against unsigned underflow of tapCnt and the associated
+   * out-of-bounds read of pCoeffs/pTapDelay when numTaps == 1. */
+  if (numTaps > 1U)
+  {
   /* Load the coefficient value and
    * increment the coefficient buffer for the next set of state values */
   coeff = *pCoeffs++;
@@ -303,6 +308,7 @@ ARM_DSP_ATTRIBUTE void arm_fir_sparse_q7(
     /* Decrement loop counter */
     blkCnt--;
   }
+  } /* if (numTaps > 1U) */
 
   /* All the output values are in pScratchOut buffer.
      Convert them into 1.15 format, saturate and store in the destination buffer. */


### PR DESCRIPTION
## Summary

`arm_fir_sparse_f32/q15/q31/q7` unconditionally load the 2nd tap's coefficient/delay (`pCoeffs[1]`/`pTapDelay[1]`) and then compute `tapCnt = (uint32_t)numTaps - 2U` **before** checking whether a 2nd tap even exists.

With `numTaps == 1` — not rejected anywhere; `arm_fir_sparse_init_*` sets `S->numTaps = numTaps` with no minimum-value validation, and neither the function docs nor `Include/dsp/filtering_functions.h` document a minimum — this:
1. reads one element past the caller's `numTaps=1`-length `pCoeffs`/`pTapDelay` arrays, and
2. underflows `tapCnt` to `0xFFFFFFFF`, turning the subsequent `while (tapCnt > 0U)` loop into a ~4.29-billion-iteration runaway that walks both arrays far out of bounds.

The identical pattern exists in all four data-type variants (verified on current `main`, commit `b82f8ee`):
- `arm_fir_sparse_f32.c` (`tapCnt = (uint32_t) numTaps - 2U;`)
- `arm_fir_sparse_q15.c`
- `arm_fir_sparse_q31.c`
- `arm_fir_sparse_q7.c`

## Fix

Wrap the entire "process 2nd tap onward, then the last tap" block in `if (numTaps > 1U) { ... }`. This mirrors how the first tap is already handled unconditionally *before* this block, and the guarded block already only makes sense when a 2nd..Nth tap exists — nothing after it depends on state set inside it (`S->stateIndex` is written once, earlier in the function, via `arm_circularWrite_*`).

## Testing

Built a standalone host reproduction (not part of this PR — `arm_circularRead_*`/`arm_circularWrite_*` plus the scalar, non-`ARM_MATH_LOOPUNROLL` control flow copied verbatim from the actual source) with `pCoeffs`/`pTapDelay` for `numTaps=1` placed via `VirtualAlloc` immediately before a reserved-but-uncommitted guard page:

- **Before fix**: crashes with a segmentation fault on the very first out-of-bounds read (`coeff = *pCoeffs++;`), exactly where predicted.
- **After fix**: completes cleanly and produces the hand-computed expected output for a 1-tap filter (`y[n] = coeff * x[n]`).
- **Regression check**: ran before/after side-by-side for `numTaps = 2, 3, 4, 8` (already-working multi-tap configurations) — byte-identical output in every case, confirming the guard does not change behavior for any previously-correct configuration.

Checked for existing/competing PRs and issues (`gh search prs`/`gh search issues --repo ARM-software/CMSIS-DSP "sparse"`) — none found.

**Note for maintainers**: `arm_fir_sparse_*` is marked `@deprecated` in its own Doxygen comments, and I couldn't find any test coverage for it under `Testing/`. If you'd rather delete the module than patch it, happy to close this — just flagging since the deprecation notice exists but the bug is real and currently shipping in `main`.

## Disclosure

Generative AI (Claude) was used to help investigate this issue and implement this fix. All changes were reviewed by me before submission.
