### PR TITLE
fix(none.h): remove implementation-defined signed shifts in clip helpers (#211)

### DIFF
--- a/Include/dsp/none.h
+++ b/Include/dsp/none.h
@@ -136,8 +136,22 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
   __STATIC_FORCEINLINE q31_t clip_q63_to_q31(
   q63_t x)
   {
-    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
-      ((0x7FFFFFFF ^ ((q31_t) (x >> 63)))) : (q31_t) x;
+    /* The saturation logic below used to rely on right shifts of a signed
+       (possibly negative) value, whose result is implementation-defined
+       (C99 6.5.7/5) and is flagged by static analysers. The equivalent
+       range check is fully defined and keeps the same behaviour. */
+    if (x > (q63_t) Q31_MAX)
+    {
+      return Q31_MAX;
+    }
+    else if (x < (q63_t) Q31_MIN)
+    {
+      return Q31_MIN;
+    }
+    else
+    {
+      return (q31_t) x;
+    }
   }
 
   /**
@@ -146,8 +160,21 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
   __STATIC_FORCEINLINE q15_t clip_q63_to_q15(
   q63_t x)
   {
-    return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
-      ((0x7FFF ^ ((q15_t) (x >> 63)))) : (q15_t) (x >> 15);
+    if (x > (q63_t) Q31_MAX)
+    {
+      return Q15_MAX;
+    }
+    else if (x < (q63_t) Q31_MIN)
+    {
+      return Q15_MIN;
+    }
+    else
+    {
+      /* Keep bits [30:15] as Q15, using an unsigned shift so the operation is
+         well defined for negative inputs (the low 16 bits are identical to the
+         previous implementation-defined signed shift). */
+      return (q15_t) ((uint64_t) x >> 15);
+    }
   }
 
   /**
@@ -156,8 +183,21 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
   __STATIC_FORCEINLINE q7_t clip_q31_to_q7(
   q31_t x)
   {
-    return ((q31_t) (x >> 24) != ((q31_t) x >> 23)) ?
-      ((0x7F ^ ((q7_t) (x >> 31)))) : (q7_t) x;
+    /* The saturation threshold is preserved exactly: the original code
+       saturates outside the signed 24-bit range (not the Q7 range). Only the
+       implementation-defined signed right shifts have been removed. */
+    if (x > (q31_t) 0x007FFFFF)
+    {
+      return Q7_MAX;
+    }
+    else if (x < -(q31_t) 0x00800000)
+    {
+      return Q7_MIN;
+    }
+    else
+    {
+      return (q7_t) x;
+    }
   }
 
   /**
@@ -166,8 +206,18 @@ __STATIC_FORCEINLINE uint32_t __ROR(uint32_t op1, uint32_t op2)
   __STATIC_FORCEINLINE q15_t clip_q31_to_q15(
   q31_t x)
   {
-    return ((q31_t) (x >> 16) != ((q31_t) x >> 15)) ?
-      ((0x7FFF ^ ((q15_t) (x >> 31)))) : (q15_t) x;
+    if (x > (q31_t) Q15_MAX)
+    {
+      return Q15_MAX;
+    }
+    else if (x < (q31_t) Q15_MIN)
+    {
+      return Q15_MIN;
+    }
+    else
+    {
+      return (q15_t) x;
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #211

## Problem

The four software-fallback clip helpers in `Include/dsp/none.h`
(`clip_q63_to_q31`, `clip_q63_to_q15`, `clip_q31_to_q7`, `clip_q31_to_q15`)
detect saturation by right-shifting a **signed, possibly negative** value, e.g.:

```c
return ((q31_t) (x >> 32) != ((q31_t) x >> 31)) ?
  ((0x7FFFFFFF ^ ((q31_t) (x >> 63)))) : (q31_t) x;
```

Per C99 §6.5.7/5, right-shifting a negative signed integer yields an
**implementation-defined** result. These are exactly the lines flagged in #211
and by static analysers (e.g. MISRA).

## Fix

Replace the shift-based detection with equivalent, fully-defined range checks
using the existing `Q31_MAX`/`Q31_MIN`/`Q15_MAX`/`Q15_MIN`/`Q7_MAX`/`Q7_MIN`
macros from `arm_math_types.h`. No signed right shifts remain; the only shift
left is an **unsigned** one in `clip_q63_to_q15`.

Behaviour is preserved **exactly** (this is a portability/UB cleanup, not a
functional change). Two quirks of the originals are deliberately kept verbatim
so nothing changes for existing callers:

- `clip_q31_to_q7` saturates outside the **signed 24-bit** range (`±2^23`), not
  the Q7 range — preserved via the `0x007FFFFF` / `0x00800000` thresholds.
- `clip_q63_to_q15` returns bits `[30:15]` of the in-range value — preserved via
  `(q15_t)((uint64_t)x >> 15)`, whose low 16 bits are identical to the old
  signed shift.

(If either quirk is actually an unintended bug, I'm happy to address it in a
separate PR — I kept this one strictly behaviour-preserving.)

## Verification

- **Bit-exact equivalence, real compiler (clang 22, C11):** the verbatim
  originals vs. the rewrites over
  - **all 2^32** `int32` inputs for `clip_q31_to_q7` and `clip_q31_to_q15`, and
  - **2×10^8** structured/random 64-bit inputs for `clip_q63_to_q31` and
    `clip_q63_to_q15`.

  Result: **0 mismatches**.
- The edited `none.h` compiles cleanly (no-DSP host config,
  `-Wall -Wextra -Wconversion -Wsign-conversion -Wshadow`, no warnings).
- Only `clip_q63_to_q31` and `clip_q31_to_q15` are called inside the library
  today (e.g. `arm_recip_q31`, `arm_div_int64_to_int32`, and several Q31 Source
  files); both are among the exhaustively/structurally verified functions.

Happy to add a dedicated unit test for these helpers if you'd like.
