### PR TITLE
arm_pid_q31: document that the final conversion does not saturate

### DIFF
--- a/Include/dsp/controller_functions.h
+++ b/Include/dsp/controller_functions.h
@@ -316,7 +316,8 @@ extern "C"
          The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
          Thus, if the accumulator result overflows it wraps around rather than clip.
          In order to avoid overflows completely the input signal must be scaled down by 2 bits as there are four additions.
-         After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+         After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then converted to 1.31 format.
+         Neither this conversion nor the following addition of y[n-1] is saturating.
  */
 __STATIC_FORCEINLINE q31_t arm_pid_q31(
   arm_pid_instance_q31 * S,


### PR DESCRIPTION
The doxygen for `arm_pid_q31` says the 2.62 accumulator is "truncated to 1.32 format and then saturated to 1.31 format". Nothing clamps: neither the narrowing nor the `out += S->state[2]` after it.

In #175 you wrote that q31 generally requires pre-scaling and that this is intended, so the sentence probably should move, not the code. That issue was about `arm_fir_q31`, not the PID; say if I have it backwards.

The clause is in ten other files; I changed only this one, which has no MVE or Neon path. Want the rest?
