### PR TITLE
zephyr: sync stdint guard define and FLOAT16 dependency

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMSIS_DSP_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
 
 zephyr_library()
 
-zephyr_library_compile_options(-Ofast)
+zephyr_library_compile_options($<TARGET_PROPERTY:compiler,optimization_fast>)
 
 zephyr_include_directories(
     ${CMSIS_DSP_DIR}/Include
@@ -20,7 +20,7 @@ else()
    zephyr_library_compile_definitions(__GNUC_PYTHON__) # Disable dependency to CMSIS Core
 endif()
 
-zephyr_library_compile_definitions(ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_)
+zephyr_library_compile_definitions(ZEPHYR_INCLUDE_TOOLCHAIN_ZEPHYR_STDINT_H_)
 
 
 # Global Feature Definitions

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -62,7 +62,7 @@ config CMSIS_DSP_AUTOVECTORIZE
 config CMSIS_DSP_FLOAT16
 	bool "Half-Precision (16-bit Float) Support"
 	default y
-	depends on FP16
+	depends on FP16_ARITHMETIC
 	help
 	  This option enables the half-precision (16-bit) floating-point
 	  operations support.


### PR DESCRIPTION
The Zephyr integration files in this module were forked from the zephyr tree in d8bad7d8 ("Reworked zephyr module"). Two later zephyr-side changes updated the in-tree copies but could not reach the copies here, so both are stale and break the build once zephyr drops its own copies in favour of these.

zephyr renamed the include guard of
include/zephyr/toolchain/zephyr_stdint.h from
ZEPHYR_INCLUDE_TOOLCHAIN_STDINT_H_ to
ZEPHYR_INCLUDE_TOOLCHAIN_ZEPHYR_STDINT_H_ (zephyr commit b04eb25b786), updating its in-tree modules/cmsis-dsp/CMakeLists.txt at the same time. The define here no longer suppresses that header, so the -imacros force-include redefines __INT32_TYPE__ from the toolchain's native 'long int' to 'int'. GCC resolves its polymorphic MVE intrinsics through _Generic associations keyed on the native int32_t, so 'const q31_t *' matches no association and Helium targets fail with:

  error: passing 'const q31_t *' {aka 'const int *'} to argument 1 of
  'vld1q', but 'q31_t' {aka 'int'} is not a valid MVE element type

zephyr then introduced CONFIG_FP16_ARITHMETIC (zephyr commit 659069617b2) to distinguish half-precision storage from half-precision arithmetic, and narrowed CMSIS_DSP_FLOAT16 to depend on it. FP16 alone is set on cores with storage-only fp16 such as Cortex-R52, where building the F16 sources lets -Ofast vectorize a _Float16 compare into a vector form the backend cannot emit, causing an internal compiler error in arm_clip_f16.c.