### PR TITLE
Document the complete test-suite addition workflow

### DIFF
--- a/Testing/README.md
+++ b/Testing/README.md
@@ -588,9 +588,18 @@ This is done in testmain.cpp.
 
 ## HOW TO ADD NEW TESTS
 
+Before implementing a new test suite:
+
+1. Add the group, suite, tests, and associated pattern, reference, output, and parameter declarations to the applicable test description file (`desc.txt`, `desc_f16.txt`, or `desc_neon.txt`).
+2. Add or update a pattern generator under `PatternGeneration`. [`PatternGeneration/Example.py`](PatternGeneration/Example.py) shows how to create input and reference patterns whose paths match the `folder` directives in the test description.
+3. Generate the pattern, reference, and parameter files under `Patterns` and `Parameters`, as applicable.
+4. Put test suite headers in `Include/Tests` and implementations in `Source/Tests`. For benchmarks, use `Include/Benchmarks` and `Source/Benchmarks` instead.
+5. Add the implementation file to the applicable source list in `CMakeLists.txt`.
+6. Rerun `preprocess.py` and `processTests.py` as described in [Generate the cpp,h and txt files from the desc.txt file](#generate-the-cpph-and-txt-files-from-the-desctxt-file) so that the generated test declarations and sources match the updated description.
+
 For a test suite MyClass, the scripts are generating an include file MyClass_decl.h 
 
-You should create another include Include/MyClass.h and another cpp file Source/MyClass.cpp in TEsting folder.
+You should create `Include/Tests/MyClass.h` and `Source/Tests/MyClass.cpp` in the `Testing` folder.
 
 MyClass.h should contain:
 


### PR DESCRIPTION
## Summary

- add a concise checklist covering test descriptions, generated patterns and references, implementation files, build registration, and regenerated sources
- direct test and benchmark files to their current `Include` and `Source` subdirectories
- link the existing pattern-generation example and generation instructions

## Context

The current instructions still point contributors to `Include/MyClass.h` and `Source/MyClass.cpp`, and they omit several required integration steps. The repository now keeps tests and benchmarks in separate subdirectories and registers implementations in `Testing/CMakeLists.txt`.

Fixes #259.

## Validation

- `git diff --check`
- verified that `Testing/PatternGeneration/Example.py`, the documented source directories, and the referenced CMake file exist on `main`
- verified that the internal README heading link targets the existing generation section

Documentation-only change. No code tests were run.