### PR TITLE
Decouple floating-point loop unrolling from DSP extensions

### DIFF
--- a/Source/FilteringFunctions/arm_conv_f32.c
+++ b/Source/FilteringFunctions/arm_conv_f32.c
@@ -260,7 +260,7 @@ ARM_DSP_ATTRIBUTE void arm_conv_f32(
     float32_t *pDst)
 {
 
-#if defined(ARM_MATH_DSP) || defined(ARM_MATH_NEON)
+#if defined(ARM_MATH_LOOPUNROLL) || defined(ARM_MATH_NEON)
 
   const float32_t *pIn1;                       /* InputA pointer */
   const float32_t *pIn2;                       /* InputB pointer */
@@ -959,7 +959,7 @@ ARM_DSP_ATTRIBUTE void arm_conv_f32(
     pDst[i] = sum;
   }
 
-#endif /* #if !defined(ARM_MATH_CM0_FAMILY) */
+#endif /* defined(ARM_MATH_LOOPUNROLL) || defined(ARM_MATH_NEON) */
 }
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */
 

--- a/Source/FilteringFunctions/arm_conv_partial_f32.c
+++ b/Source/FilteringFunctions/arm_conv_partial_f32.c
@@ -95,7 +95,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_f32(
         uint32_t firstIndex,
         uint32_t numPoints)
 {
-#if defined (ARM_MATH_DSP)
+#if defined (ARM_MATH_LOOPUNROLL)
   const float32_t *pIn1 = pSrcA;                       /* InputA pointer */
   const float32_t *pIn2 = pSrcB;                       /* InputB pointer */
         float32_t *pOut = pDst;                        /* Output pointer */
@@ -679,7 +679,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_conv_partial_f32(
   /* Return to application */
   return (status);
 
-#endif /* defined(ARM_MATH_DSP) */
+#endif /* defined(ARM_MATH_LOOPUNROLL) */
 }
 
 /**

--- a/Source/FilteringFunctions/arm_correlate_f16.c
+++ b/Source/FilteringFunctions/arm_correlate_f16.c
@@ -467,7 +467,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f16(
         float16_t * pDst)
 {
 
-#if defined(ARM_MATH_DSP) && !defined(ARM_MATH_AUTOVECTORIZE)
+#if defined(ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE)
   
   const float16_t *pIn1;                               /* InputA pointer */
   const float16_t *pIn2;                               /* InputB pointer */
@@ -1105,7 +1105,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f16(
       *pDst++ = sum;
   }
 
-#endif /* #if !defined(ARM_MATH_CM0_FAMILY) */
+#endif /* defined(ARM_MATH_LOOPUNROLL) && !defined(ARM_MATH_AUTOVECTORIZE) */
 
 }
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */

--- a/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/Source/FilteringFunctions/arm_correlate_f32.c
@@ -317,7 +317,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f32(
         float32_t * pDst)
 {
 
-#if defined(ARM_MATH_DSP) || defined(ARM_MATH_NEON) 
+#if defined(ARM_MATH_LOOPUNROLL) || defined(ARM_MATH_NEON)
   
   const float32_t *pIn1;                               /* InputA pointer */
   const float32_t *pIn2;                               /* InputB pointer */
@@ -1095,7 +1095,7 @@ ARM_DSP_ATTRIBUTE void arm_correlate_f32(
       *pDst++ = sum;
   }
 
-#endif /* #if !defined(ARM_MATH_CM0_FAMILY) */
+#endif /* defined(ARM_MATH_LOOPUNROLL) || defined(ARM_MATH_NEON) */
 
 }
 #endif /* defined(ARM_MATH_MVEF) && !defined(ARM_MATH_AUTOVECTORIZE) */


### PR DESCRIPTION
## Summary

- select the loop-unrolled scalar implementations of `arm_conv_f32`, `arm_conv_partial_f32`, `arm_correlate_f32`, and `arm_correlate_f16` using `ARM_MATH_LOOPUNROLL`
- retain the existing NEON selection for the f32 functions and the autovectorisation fallback for f16
- update the closing preprocessor comments to describe the actual conditions

## Context

`ARM_MATH_DSP` represents integer DSP extensions and does not determine whether these floating-point implementations can use manual loop unrolling. The existing outer guards therefore prevent `ARM_MATH_LOOPUNROLL` from selecting the unrolled scalar path unless `ARM_MATH_DSP` is also defined.

This change makes the outer selection consistent with the loop-unroll option discussed in #193 while leaving the algorithms unchanged.

Fixes #193.

## Validation

- `git diff --check`
- compiled all four affected translation units with GCC 13.3.0 and `-Wall -Wextra -Werror -Wmissing-prototypes` under:
  - `ARM_MATH_LOOPUNROLL`
  - plain scalar configuration
  - `ARM_MATH_DSP` without loop unrolling
  - `ARM_MATH_LOOPUNROLL` with `ARM_MATH_AUTOVECTORIZE`
- linked the patched unrolled and scalar implementations under separate symbols and compared representative results for f32 convolution, f32 partial convolution, f32 correlation, and f16 correlation; all outputs matched within the selected floating-point tolerances

The CMake-based repository suite was not run because CMake is unavailable in the local environment.