### PR TITLE
Clarify the correlation output layout

### DIFF
--- a/Source/FilteringFunctions/arm_correlate_f32.c
+++ b/Source/FilteringFunctions/arm_correlate_f32.c
@@ -65,8 +65,10 @@
                    \f]
   @par
                    The <code>pSrcA</code> points to the first input vector of length <code>srcALen</code> and <code>pSrcB</code> points to the second input vector of length <code>srcBLen</code>.
-                   The result <code>c[n]</code> is of length <code>2 * max(srcALen, srcBLen) - 1</code> and is defined over the interval <code>n=0, 1, 2, ..., (2 * max(srcALen, srcBLen) - 2)</code>.
-                   The output result is written to <code>pDst</code> and the calling function must allocate <code>2 * max(srcALen, srcBLen) - 1</code> words for the result.
+                   The correlation has <code>srcALen + srcBLen - 1</code> values, but the output is zero-padded to a length of <code>2 * max(srcALen, srcBLen) - 1</code>.
+                   The calling function must allocate <code>2 * max(srcALen, srcBLen) - 1</code> words for <code>pDst</code>.
+                   If <code>srcALen &gt;= srcBLen</code>, the first <code>srcALen - srcBLen</code> elements are zero padding and the correlation values occupy the remaining elements.
+                   If <code>srcALen &lt; srcBLen</code>, the correlation values occupy the first <code>srcALen + srcBLen - 1</code> elements and the remaining elements are zero padding.
 
   @note
                    The <code>pDst</code> should be initialized to all zeros before being used.


### PR DESCRIPTION
## Summary

- distinguish the `srcALen + srcBLen - 1` correlation values from the larger zero-padded destination buffer
- document whether the padding appears before or after the correlation values for unequal input lengths
- retain the existing destination allocation and zero-initialisation requirements

## Context

The correlation implementations intentionally use a destination length of `2 * max(srcALen, srcBLen) - 1`. The existing group documentation describes that entire buffer as the correlation result, but does not show where the actual correlation values are located when the input lengths differ.

This change documents the existing layout without changing the implementation or API.

Fixes #120.

## Validation

- `git diff --check`
- compiled the scalar `arm_correlate_f32.c` path with GCC 13.3.0 and `-Wall -Wextra -Werror`, using minimal test-only stubs for the external CMSIS Core headers
- ran focused C assertions for both unequal-length orders and confirmed the documented leading and trailing zero padding

Documentation-only change. The repository test suite was not run.