### PR TITLE
Document in-place complex magnitude support

### DIFF
--- a/Source/ComplexMathFunctions/arm_cmplx_mag_f32.c
+++ b/Source/ComplexMathFunctions/arm_cmplx_mag_f32.c
@@ -48,6 +48,11 @@
   The input array has a total of <code>2*numSamples</code> values;
   the output array has a total of <code>numSamples</code> values.
 
+  @par           In-place operation
+  The source and destination buffers may be identical. In this case, the
+  <code>numSamples</code> magnitude values overwrite the first <code>numSamples</code>
+  elements of the input buffer.
+
   The underlying algorithm is used:
 
   <pre>


### PR DESCRIPTION
## Summary

- document that complex magnitude functions support identical source and destination buffers
- state that in-place operation writes the magnitude results over the first `numSamples` input elements
- place the guarantee in the shared complex magnitude group documentation so it covers every supported data type

## Context

The maintainer confirmed in #110 that complex magnitude can be processed in place, but the public documentation does not state this. The missing guarantee can cause callers to allocate an unnecessary output buffer.

This addresses the confirmed complex-magnitude portion of #110. It does not make any claim about the filtering functions discussed in that issue.

## Validation

- `git diff --check`
- compiled the f16, f32, f64, q15, fast q15, and q31 scalar implementations with GCC 13.3.0 and `-Wall -Wextra -Werror`
- ran each implementation with separate buffers and with `pSrc == pDst` in plain scalar and loop-unrolled builds; all five-sample outputs matched byte for byte
- inspected the current NEON and MVE branches to confirm that input blocks are loaded before overlapping output elements are written

Documentation-only change. The full repository test suite was not run.