### PR TITLE
Document the LDLT output representation

### DIFF
--- a/Include/dsp/matrix_functions.h
+++ b/Include/dsp/matrix_functions.h
@@ -752,11 +752,14 @@ void arm_mat_init_f64(
    * @brief Floating-point LDL decomposition of Symmetric Positive Semi-Definite Matrix.
    * @param[in]  src   points to the instance of the input floating-point matrix structure.
    * @param[out] l   points to the instance of the output floating-point triangular matrix structure.
-   * @param[out] d   points to the instance of the output floating-point diagonal matrix structure.
-   * @param[out] p   points to the instance of the output floating-point permutation vector.
+   * @param[out] d   points to the N x N output floating-point diagonal matrix structure.
+   * @param[out] pp  points to the output permutation vector of length N.
    * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
    * If the input matrix does not have a decomposition, then the algorithm terminates and returns error status ARM_MATH_DECOMPOSITION_FAILURE.
    * The decomposition is returning a lower triangular matrix.
+   * For each decomposition step k, pp[k] records the row and column index swapped with k.
+   * Construct P by starting with an N x N identity matrix and swapping rows k and pp[k]
+   * for k = 0, 1, ..., N - 1, in that order.
    */
   arm_status arm_mat_ldlt_f32(
   const arm_matrix_instance_f32 * src,
@@ -768,11 +771,14 @@ void arm_mat_init_f64(
    * @brief Floating-point LDL decomposition of Symmetric Positive Semi-Definite Matrix.
    * @param[in]  src   points to the instance of the input floating-point matrix structure.
    * @param[out] l   points to the instance of the output floating-point triangular matrix structure.
-   * @param[out] d   points to the instance of the output floating-point diagonal matrix structure.
-   * @param[out] p   points to the instance of the output floating-point permutation vector.
+   * @param[out] d   points to the N x N output floating-point diagonal matrix structure.
+   * @param[out] pp  points to the output permutation vector of length N.
    * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
    * If the input matrix does not have a decomposition, then the algorithm terminates and returns error status ARM_MATH_DECOMPOSITION_FAILURE.
    * The decomposition is returning a lower triangular matrix.
+   * For each decomposition step k, pp[k] records the row and column index swapped with k.
+   * Construct P by starting with an N x N identity matrix and swapping rows k and pp[k]
+   * for k = 0, 1, ..., N - 1, in that order.
    */
   arm_status arm_mat_ldlt_f64(
   const arm_matrix_instance_f64 * src,

--- a/Source/MatrixFunctions/arm_mat_ldlt_f32.c
+++ b/Source/MatrixFunctions/arm_mat_ldlt_f32.c
@@ -50,7 +50,7 @@
    * @param[in]  pSrc   points to the instance of the input floating-point matrix structure.
    * @param[out] pl   points to the instance of the output floating-point triangular matrix structure.
    * @param[out] pd   points to the instance of the output floating-point diagonal matrix structure.
-   * @param[out] pp   points to the instance of the output floating-point permutation vector.
+   * @param[out] pp   points to the output permutation vector of length N.
    * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
    * @return        execution status
                    - \ref ARM_MATH_SUCCESS       : Operation successful
@@ -58,6 +58,11 @@
                    - \ref ARM_MATH_DECOMPOSITION_FAILURE      : Input matrix cannot be decomposed
    * @par
    *  Computes the LDL^t decomposition of a matrix A such that P A P^t = L D L^t.
+   * @par          Output representation
+   *  The output <code>pd</code> is an N x N diagonal matrix whose off-diagonal elements are zero.
+   *  For each decomposition step k, <code>pp[k]</code> records the row and column index swapped with k.
+   *  To construct P, start with an N x N identity matrix and swap rows k and <code>pp[k]</code>
+   *  for k = 0, 1, ..., N - 1, in that order.
    */
 ARM_DSP_ATTRIBUTE arm_status arm_mat_ldlt_f32(
   const arm_matrix_instance_f32 * pSrc,
@@ -309,7 +314,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_ldlt_f32(
    * @param[in]  pSrc   points to the instance of the input floating-point matrix structure.
    * @param[out] pl   points to the instance of the output floating-point triangular matrix structure.
    * @param[out] pd   points to the instance of the output floating-point diagonal matrix structure.
-   * @param[out] pp   points to the instance of the output floating-point permutation vector.
+   * @param[out] pp   points to the output permutation vector of length N.
    * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
    * @return        execution status
                    - \ref ARM_MATH_SUCCESS       : Operation successful
@@ -317,6 +322,11 @@ ARM_DSP_ATTRIBUTE arm_status arm_mat_ldlt_f32(
                    - \ref ARM_MATH_DECOMPOSITION_FAILURE      : Input matrix cannot be decomposed
    * @par
    *  Computes the LDL^t decomposition of a matrix A such that P A P^t = L D L^t.
+   * @par          Output representation
+   *  The output <code>pd</code> is an N x N diagonal matrix whose off-diagonal elements are zero.
+   *  For each decomposition step k, <code>pp[k]</code> records the row and column index swapped with k.
+   *  To construct P, start with an N x N identity matrix and swap rows k and <code>pp[k]</code>
+   *  for k = 0, 1, ..., N - 1, in that order.
    */
 ARM_DSP_ATTRIBUTE arm_status arm_mat_ldlt_f32(
   const arm_matrix_instance_f32 * pSrc,

--- a/Source/MatrixFunctions/arm_mat_ldlt_f64.c
+++ b/Source/MatrixFunctions/arm_mat_ldlt_f64.c
@@ -49,7 +49,7 @@
    * @param[in]  pSrc   points to the instance of the input floating-point matrix structure.
    * @param[out] pl   points to the instance of the output floating-point triangular matrix structure.
    * @param[out] pd   points to the instance of the output floating-point diagonal matrix structure.
-   * @param[out] pp   points to the instance of the output floating-point permutation vector.
+   * @param[out] pp   points to the output permutation vector of length N.
    * @return The function returns ARM_MATH_SIZE_MISMATCH, if the dimensions do not match.
    * @return        execution status
                    - \ref ARM_MATH_SUCCESS       : Operation successful
@@ -57,6 +57,11 @@
                    - \ref ARM_MATH_DECOMPOSITION_FAILURE      : Input matrix cannot be decomposed
    * @par
    *  Computes the LDL^t decomposition of a matrix A such that P A P^t = L D L^t.
+   * @par          Output representation
+   *  The output <code>pd</code> is an N x N diagonal matrix whose off-diagonal elements are zero.
+   *  For each decomposition step k, <code>pp[k]</code> records the row and column index swapped with k.
+   *  To construct P, start with an N x N identity matrix and swap rows k and <code>pp[k]</code>
+   *  for k = 0, 1, ..., N - 1, in that order.
    */
 
 ARM_DSP_ATTRIBUTE arm_status arm_mat_ldlt_f64(


### PR DESCRIPTION
## Summary

- document that the LDLT `D` output is an N x N diagonal matrix with zero off-diagonal elements
- define `pp` as an N-element sequence of row and column swaps
- explain the order required to reconstruct the permutation matrix `P`
- correct the public header parameter name from `p` to `pp`

## Context

Issue #119 identifies two separate concerns: the square representation of `D` and the lack of usable documentation for the permutation vector. Changing `D` to a vector would alter the public API. This change preserves the current API and makes both existing output representations explicit, including the exact procedure for constructing `P`.

This addresses the documentation portion of #119.

## Validation

- `git diff --check`
- compiled the scalar f32 and f64 LDLT implementations with GCC 13.3.0 and `-Wall -Wextra -Werror`, using minimal test-only stubs for external CMSIS Core definitions
- ran a focused f32/f64 test that reconstructed `P` from `pp`, verified `P A P^T = L D L^T`, and checked that every off-diagonal element of `D` is zero
- confirmed that the documented reconstruction order matches the existing f32 and f64 repository tests

Documentation-only change. The full repository test suite was not run.