### PR TITLE
Document in-place matrix addition, subtraction, and scaling

### DIFF
--- a/Source/MatrixFunctions/arm_mat_add_f32.c
+++ b/Source/MatrixFunctions/arm_mat_add_f32.c
@@ -64,6 +64,11 @@
   The functions check to make sure that
   <code>pSrcA</code>, <code>pSrcB</code>, and <code>pDst</code> have the same
   number of rows and columns.
+
+  @par In-place operation
+  The destination matrix may be the same instance as either input matrix.
+  Its data buffer may also be identical to either source data buffer. Other
+  overlapping buffer arrangements are not supported.
  */
 
 /**

--- a/Source/MatrixFunctions/arm_mat_scale_f32.c
+++ b/Source/MatrixFunctions/arm_mat_scale_f32.c
@@ -66,6 +66,11 @@
   <pre>
       scale = scaleFract * 2^shift.
   </pre>
+
+  @par In-place operation
+  The destination matrix may be the same instance as the input matrix. Its
+  data buffer may also be identical to the source data buffer. Other
+  overlapping buffer arrangements are not supported.
  */
 
 /**

--- a/Source/MatrixFunctions/arm_mat_sub_f32.c
+++ b/Source/MatrixFunctions/arm_mat_sub_f32.c
@@ -63,6 +63,11 @@
   The functions check to make sure that
   <code>pSrcA</code>, <code>pSrcB</code>, and <code>pDst</code> have the same
   number of rows and columns.
+
+  @par In-place operation
+  The destination matrix may be the same instance as either input matrix.
+  Its data buffer may also be identical to either source data buffer. Other
+  overlapping buffer arrangements are not supported.
  */
 
 /**


### PR DESCRIPTION
## Summary

- document the in-place contract for matrix addition, subtraction, and scaling
- clarify that the destination may reuse a source matrix instance or the identical source data buffer
- distinguish exact source and destination aliasing from unsupported partial buffer overlap

## Context

Issue #44 asks which matrix operations support in-place use and notes that the behavior is absent from the documentation. A maintainer confirmed that operations such as scaling and addition support it and that the documentation should be improved.

The current addition, subtraction, and scaling implementations read each input element or vector block before writing the corresponding output. This permits exact destination aliasing for the available f16, f32, f64, q15, and q31 variants without changing their APIs or implementations.

This addresses #44.

## Validation

- `git diff --check`
- compiled all 13 documented scalar implementations with GCC 13.3.0 and `-Wall -Wextra -Werror`, `ARM_MATH_MATRIX_CHECK`, and configurations both with and without `ARM_MATH_LOOPUNROLL`
- ran focused tests for exact destination aliasing with either source matrix and with a distinct destination instance sharing a source data buffer
- covered f16, f32, f64, q15, and q31 variants with seven-element matrices, including loop remainders and fixed-point saturation cases
- audited the current Helium and Neon paths to confirm that each vector block is loaded before its destination block is written; those target-specific paths were not executed locally

Documentation-only change. The full repository test suite was not run.