### PR TITLE
Remove parity branches from arm_sqrt_q15

### DIFF
--- a/Source/FastMathFunctions/arm_sqrt_q15.c
+++ b/Source/FastMathFunctions/arm_sqrt_q15.c
@@ -65,15 +65,11 @@ ARM_DSP_ATTRIBUTE arm_status arm_sqrt_q15(
   {
     signBits1 = __CLZ(number) - 17;
 
+    /* Force an even normalization shift. */
+    signBits1 &= ~1;
+
     /* Shift by the number of signBits1 */
-    if ((signBits1 % 2) == 0)
-    {
-      number = number << signBits1;
-    }
-    else
-    {
-      number = number << (signBits1 - 1);
-    }
+    number = number << signBits1;
     /* Start value for 1/sqrt(x) for the Newton iteration */
     var1 = sqrt_initial_lut_q15[(number>> 11) - (Q12QUARTER >> 11)];
 
@@ -100,14 +96,7 @@ ARM_DSP_ATTRIBUTE arm_status arm_sqrt_q15(
     var1 = ((q15_t) (((q31_t) number * var1) >> 12));
 
     /* Shift the output down accordingly */
-    if ((signBits1 % 2) == 0)
-    {
-      var1 = var1 >> (signBits1 / 2);
-    }
-    else
-    {
-      var1 = var1 >> ((signBits1 - 1) / 2);
-    }
+    var1 = var1 >> (signBits1 / 2);
     *pOut = var1;
 
 


### PR DESCRIPTION
## Summary

- force the Q15 square-root normalization shift to an even value
- replace the input-normalization parity branch with one shift
- replace the output-rescaling parity branch with one shift
- preserve the existing lookup table, Newton iterations, status values, and output values

## Context

Issue #9 proposes two independent improvements to `arm_sqrt_q15`. One is to make the normalization shift even before it is used, which removes parity checks before and after the inverse-square-root calculation. The other is a wider internal format and new lookup table for greater precision.

This change implements only the branch-removal optimization. Rounding an odd normalization shift down to the preceding even value is exactly what both existing odd branches already do, so the numerical behavior remains unchanged.

This addresses the normalization-shift portion of #9.

## Validation

- `git diff --check`
- compiled the original and patched implementations under separate symbols with GCC 13.3.0 and `-Wall -Wextra -Werror`
- repeated the comparison at `-O0` and `-O3`
- exhaustively compared status and output for all 65,536 possible Q15 inputs; every result matched exactly

The full repository test suite was not run.