### PR TITLE
Use documented MFCC output formats in Python example

### DIFF
--- a/PythonWrapper/examples/testmfcc.py
+++ b/PythonWrapper/examples/testmfcc.py
@@ -98,7 +98,8 @@ class TestMFCC_MFCC(unittest.TestCase):
            errorStatus,resQ31=dsp.arm_mfcc_q31(mfccq31,debugQ31,tmp,tmp2=tmp2)
         else:
            errorStatus,resQ31=dsp.arm_mfcc_q31(mfccq31,debugQ31,tmp)
-        res=self.FFTSize*Q31toF32(resQ31)
+        # arm_mfcc_q31 returns q8.23 values.
+        res=resQ31 / float(1 << 23)
 
         assert_allclose(res,ref,4e-5,4e-5)
 
@@ -140,7 +141,8 @@ class TestMFCC_MFCC(unittest.TestCase):
            errorStatus,resQ15=dsp.arm_mfcc_q15(mfccq15,debugQ15,tmp,tmp2=tmp2)
         else:
            errorStatus,resQ15=dsp.arm_mfcc_q15(mfccq15,debugQ15,tmp)
-        res=self.FFTSize*Q15toF32(resQ15)
+        # arm_mfcc_q15 returns q8.7 values.
+        res=resQ15 / float(1 << 7)
 
         assert_allclose(res,ref,3e-3,1e-2)
 


### PR DESCRIPTION
Addresses #279

## Summary

- convert Q31 MFCC results from the documented q8.23 format with a fixed `2^23` divisor
- convert Q15 MFCC results from the documented q8.7 format with a fixed `2^7` divisor
- remove the conversion's accidental dependence on the example's 256-point FFT length

## Context

`arm_mfcc_q31` and `arm_mfcc_q15` return q8.23 and q8.7 values respectively. The example previously converted them as ordinary Q31 and Q15 values and multiplied by `FFTSize`. That gives the expected scale for the current 256-point test only because both output formats have eight integer bits. A different FFT length would scale the displayed MFCC values incorrectly.

This follows the maintainer's format clarification in #279 and makes the example match the function documentation.

## Validation

- `python -m py_compile PythonWrapper/examples/testmfcc.py`
- focused NumPy regression with representative signed Q31 and Q15 outputs
- confirmed the new conversions match the existing 256-point expectations and remain constant when a different hypothetical FFT length is used
- `git diff --check`

The full example test was not run because the compiled `cmsisdsp` extension modules are unavailable in the local environment.