### PR TITLE
Correct Q31 scalar output saturation documentation

### DIFF
--- a/Source/FilteringFunctions/arm_conv_q31.c
+++ b/Source/FilteringFunctions/arm_conv_q31.c
@@ -56,7 +56,8 @@
                    The input signals should be scaled down to avoid intermediate overflows.
                    Scale down the inputs by log2(min(srcALen, srcBLen)) (log2 is read as log to the base 2) times to avoid overflows,
                    as maximum of min(srcALen, srcBLen) number of additions are carried internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
 
   @remark
                    Refer to \ref arm_conv_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_correlate_q31.c
+++ b/Source/FilteringFunctions/arm_correlate_q31.c
@@ -56,7 +56,8 @@
                    The input signals should be scaled down to avoid intermediate overflows.
                    Scale down one of the inputs by 1/min(srcALen, srcBLen)to avoid overflows since a
                    maximum of min(srcALen, srcBLen) number of additions is carried internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
 
   @remark
                    Refer to \ref arm_correlate_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_fir_decimate_q31.c
+++ b/Source/FilteringFunctions/arm_fir_decimate_q31.c
@@ -52,7 +52,8 @@
                    The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by log2(numTaps) bits (where log2 is read as log to the base 2).
-                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
 
  @remark
                    Refer to \ref arm_fir_decimate_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_fir_interpolate_q31.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_q31.c
@@ -53,7 +53,8 @@
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by <code>1/(numTaps/L)</code>.
                    since <code>numTaps/L</code> additions occur per output sample.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
  */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/FilteringFunctions/arm_fir_q31.c
+++ b/Source/FilteringFunctions/arm_fir_q31.c
@@ -53,7 +53,8 @@
                    The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by log2(numTaps) bits.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
 
  @remark
                    Refer to \ref arm_fir_fast_q31() for a faster but less precise implementation of this filter.

--- a/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -56,8 +56,8 @@
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by
                    log2(numTaps) bits. The reference signal should not be scaled down.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is shifted
-                   and saturated to 1.31 format to yield the final result.
+                   The scalar implementation shifts the 2.62 accumulator according to postShift
+                   to yield the final 1.31 result. This conversion does not saturate.
                    The output signal and error signal are in 1.31 format.
  @par
   	               In this filter, filter coefficients are updated for each sample and the

--- a/Source/FilteringFunctions/arm_lms_q31.c
+++ b/Source/FilteringFunctions/arm_lms_q31.c
@@ -57,8 +57,8 @@
                    In order to avoid overflows completely the input signal must be scaled down by
                    log2(numTaps) bits.
                    The reference signal should not be scaled down.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is shifted
-                   and saturated to 1.31 format to yield the final result.
+                   The scalar implementation shifts the 2.62 accumulator according to postShift
+                   to yield the final 1.31 result. This conversion does not saturate.
                    The output signal and error signal are in 1.31 format.
  @par
                    In this filter, filter coefficients are updated for each sample and

--- a/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
+++ b/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
@@ -58,7 +58,8 @@
                    distorts the result. The input signals should be scaled down to avoid intermediate
                    overflows. The input is thus scaled down by log2(numColsA) bits
                    to avoid overflows, as a total of numColsA additions are performed internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
   @remark
                    Refer to \ref arm_mat_mult_fast_q31() for a faster but less precise implementation of this function.
   @remark

--- a/Source/MatrixFunctions/arm_mat_mult_q31.c
+++ b/Source/MatrixFunctions/arm_mat_mult_q31.c
@@ -57,7 +57,8 @@
                    distorts the result. The input signals should be scaled down to avoid intermediate
                    overflows. The input is thus scaled down by log2(numColsA) bits
                    to avoid overflows, as a total of numColsA additions are performed internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The scalar implementation right shifts the 2.62 accumulator by 31 bits to yield the final 1.31 result.
+                   This conversion does not saturate.
   @remark
                    Refer to \ref arm_mat_mult_fast_q31() for a faster but less precise implementation of this function.
  */


### PR DESCRIPTION
Addresses #328

## Summary

- correct the final-conversion documentation for nine Q31 filtering and matrix functions
- state that the scalar paths convert their 2.62 accumulators without saturation
- describe the LMS and normalized LMS shift in terms of `postShift`
- leave `arm_mat_cmplx_mult_q31` unchanged because its scalar path calls `clip_q63_to_q31`

## Context

The affected comments currently promise saturation while the scalar implementations store a shifted accumulator through a plain `q31_t` conversion. Issue #175 confirms that non-saturating Q31 behavior is intentional for scalar kernels and also notes that Helium can saturate. The revised wording is therefore explicitly scoped to the scalar implementations.

## Validation

- scripted source audit across all nine files
- confirmed every affected comment now states the non-saturating scalar behavior
- confirmed none of the nine files retain the reported saturation claims
- confirmed the saturating `arm_mat_cmplx_mult_q31` exception remains unchanged
- `git diff --check`

The full CMSIS-DSP test suite was not run because this change only updates Doxygen comments and does not alter compiled code.