### PR TITLE
docs(q31): correct false '...saturated to 1.31 format' claim in 9 files

### DIFF
--- a/Source/FilteringFunctions/arm_conv_q31.c
+++ b/Source/FilteringFunctions/arm_conv_q31.c
@@ -56,7 +56,8 @@
                    The input signals should be scaled down to avoid intermediate overflows.
                    Scale down the inputs by log2(min(srcALen, srcBLen)) (log2 is read as log to the base 2) times to avoid overflows,
                    as maximum of min(srcALen, srcBLen) number of additions are carried internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The 2.62 accumulator is right shifted by 31 bits and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
 
   @remark
                    Refer to \ref arm_conv_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_correlate_q31.c
+++ b/Source/FilteringFunctions/arm_correlate_q31.c
@@ -56,7 +56,8 @@
                    The input signals should be scaled down to avoid intermediate overflows.
                    Scale down one of the inputs by 1/min(srcALen, srcBLen)to avoid overflows since a
                    maximum of min(srcALen, srcBLen) number of additions is carried internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The 2.62 accumulator is right shifted by 31 bits and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
 
   @remark
                    Refer to \ref arm_correlate_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_fir_decimate_q31.c
+++ b/Source/FilteringFunctions/arm_fir_decimate_q31.c
@@ -52,7 +52,8 @@
                    The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by log2(numTaps) bits (where log2 is read as log to the base 2).
-                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then converted to 1.31 format.
+                   This conversion is not saturating.
 
  @remark
                    Refer to \ref arm_fir_decimate_fast_q31() for a faster but less precise implementation of this function.

--- a/Source/FilteringFunctions/arm_fir_interpolate_q31.c
+++ b/Source/FilteringFunctions/arm_fir_interpolate_q31.c
@@ -53,7 +53,8 @@
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by <code>1/(numTaps/L)</code>.
                    since <code>numTaps/L</code> additions occur per output sample.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then saturated to 1.31 format.
+                   After all multiply-accumulates are performed, the 2.62 accumulator is truncated to 1.32 format and then converted to 1.31 format.
+                   This conversion is not saturating.
  */
 
 #if defined(ARM_MATH_MVEI) && !defined(ARM_MATH_AUTOVECTORIZE)

--- a/Source/FilteringFunctions/arm_fir_q31.c
+++ b/Source/FilteringFunctions/arm_fir_q31.c
@@ -53,7 +53,8 @@
                    The accumulator has a 2.62 format and maintains full precision of the intermediate multiplication results but provides only a single guard bit.
                    Thus, if the accumulator result overflows it wraps around rather than clip.
                    In order to avoid overflows completely the input signal must be scaled down by log2(numTaps) bits.
-                   After all multiply-accumulates are performed, the 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   After all multiply-accumulates are performed, the 2.62 accumulator is right shifted by 31 bits and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
 
  @remark
                    Refer to \ref arm_fir_fast_q31() for a faster but less precise implementation of this filter.

--- a/Source/FilteringFunctions/arm_lms_norm_q31.c
+++ b/Source/FilteringFunctions/arm_lms_norm_q31.c
@@ -57,7 +57,8 @@
                    In order to avoid overflows completely the input signal must be scaled down by
                    log2(numTaps) bits. The reference signal should not be scaled down.
                    After all multiply-accumulates are performed, the 2.62 accumulator is shifted
-                   and saturated to 1.31 format to yield the final result.
+                   and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
                    The output signal and error signal are in 1.31 format.
  @par
   	               In this filter, filter coefficients are updated for each sample and the

--- a/Source/FilteringFunctions/arm_lms_q31.c
+++ b/Source/FilteringFunctions/arm_lms_q31.c
@@ -58,7 +58,8 @@
                    log2(numTaps) bits.
                    The reference signal should not be scaled down.
                    After all multiply-accumulates are performed, the 2.62 accumulator is shifted
-                   and saturated to 1.31 format to yield the final result.
+                   and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
                    The output signal and error signal are in 1.31 format.
  @par
                    In this filter, filter coefficients are updated for each sample and

--- a/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
+++ b/Source/MatrixFunctions/arm_mat_mult_opt_q31.c
@@ -58,7 +58,8 @@
                    distorts the result. The input signals should be scaled down to avoid intermediate
                    overflows. The input is thus scaled down by log2(numColsA) bits
                    to avoid overflows, as a total of numColsA additions are performed internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The 2.62 accumulator is right shifted by 31 bits and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
   @remark
                    Refer to \ref arm_mat_mult_fast_q31() for a faster but less precise implementation of this function.
   @remark

--- a/Source/MatrixFunctions/arm_mat_mult_q31.c
+++ b/Source/MatrixFunctions/arm_mat_mult_q31.c
@@ -57,7 +57,8 @@
                    distorts the result. The input signals should be scaled down to avoid intermediate
                    overflows. The input is thus scaled down by log2(numColsA) bits
                    to avoid overflows, as a total of numColsA additions are performed internally.
-                   The 2.62 accumulator is right shifted by 31 bits and saturated to 1.31 format to yield the final result.
+                   The 2.62 accumulator is right shifted by 31 bits and converted to 1.31 format to yield the final result.
+                   This conversion is not saturating.
   @remark
                    Refer to \ref arm_mat_mult_fast_q31() for a faster but less precise implementation of this function.
  */


### PR DESCRIPTION
## Bug

Following the pattern already accepted in #327 (`arm_pid_q31`, merged), these nine files' `Scaling and Overflow Behavior` doc comments claim the final 2.62 -> 1.31 narrowing conversion **saturates**. It does not: in every case the scalar path narrows with a bare `(q31_t)` cast (a right shift then truncating cast, e.g. `(q31_t) (sum >> 31)` or `*pOut++ = (q31_t) acc;`), with no call to a saturating helper such as `clip_q63_to_q31` anywhere in that narrowing step. A caller relying on the documented saturation guarantee to bound worst-case output would instead observe silent wraparound. See #328, which enumerated exactly these nine files.

I independently re-verified each file rather than trusting the issue's grep-based classification at face value. Notably, `arm_lms_q31.c` and `arm_lms_norm_q31.c` **do** call `clip_q63_to_q31()` — but only in the coefficient-update path (LMS tap adaptation), never on the accumulator-to-output narrowing the doc comment actually describes, so the same fix applies there too, not just to the files with zero `clip_q63_to_q31` occurrences.

`arm_mat_cmplx_mult_q31.c` (also mentioned in #328) is intentionally **excluded**: its scalar path genuinely calls `clip_q63_to_q31` on the output, so its existing doc wording is already correct.

## Fix

Reword each doc comment from "...saturated to 1.31 format..." to "...converted to 1.31 format..." plus an explicit "This conversion is not saturating." line, mirroring the exact wording pattern used in the already-merged #327.

## Scope

This covers the documented **scalar-path** conversion only. The MVEI/Helium and NEON kernels narrow through vector intrinsics rather than a `(q31_t)` cast, so I made no attempt to check whether Helium's narrowing actually saturates — consistent with what #328 already flagged as unverified and out of scope for this PR.

## Verification

This is a comment-only change — no code paths are touched, so there's nothing for a compiler to meaningfully check. Verified by reading each file's actual narrowing site (see above) and by `git diff` review that all nine `/** */` blocks remain well-formed.

Fixes #328